### PR TITLE
Remove distance from everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ galario
 [![Build Status](https://travis-ci.org/mtazzari/galario.svg?branch=master)](https://travis-ci.org/mtazzari/galario)
 [![License: LGPL v3](https://img.shields.io/badge/License-LGPL%20v3-blue.svg)](https://www.gnu.org/licenses/lgpl-3.0)
 
-**galario** exploits the computing power of modern graphic cards (GPUs) to accelerate the comparison of model
-predictions to the observations of radio interferometers. Namely, it speeds up the computation of the synthetic visibilities
+**galario** is a library that exploits the computing power of modern graphic cards (GPUs) to accelerate the comparison of model
+predictions to radio interferometer observations. Namely, it speeds up the computation of the synthetic visibilities
 given a model image (or an axisymmetric brightness profile) and their comparison to the observations.
 
 Check out the [documentation](https://mtazzari.github.io/galario/) and the [installation instructions](https://mtazzari.github.io/galario/install.html).

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 galario
 =======
 
-**Gpu Accelerated Library for Analysing Radio Interferometry Observations**
+**Gpu Accelerated Library for Analysing Radio Interferometer Observations**
 
 [![Release Number](https://img.shields.io/github/release/mtazzari/galario/all.svg)](https://github.com/mtazzari/galario/releases)
 [![Build Status](https://travis-ci.org/mtazzari/galario.svg?branch=master)](https://travis-ci.org/mtazzari/galario)

--- a/docs/C-api.rst
+++ b/docs/C-api.rst
@@ -66,7 +66,7 @@ These are four main functions that should serve the standard use of galario.
 
 .. function::
    void galario_sample_profile(int nr, dreal* const ints,
-   dreal Rmin, dreal dR, dreal dxy, int nxy, dreal dist, dreal inc,
+   dreal Rmin, dreal dR, dreal dxy, int nxy, dreal inc,
    dreal dRA, dreal dDec, dreal duv, dreal PA, int nd, const dreal *u,
    const dreal *v, dcomplex *fint);
 
@@ -81,7 +81,6 @@ These are four main functions that should serve the standard use of galario.
    :param dR: Radial-grid cell size.
    :param dxy: Image cell size.
    :param nxy: Number of image pixels in x- and y-direction.
-   :param dist: Distance to source.
    :param inc: Inclination.
    :param dRa: Rectascension offset.
    :param dDec: Dec. offset.
@@ -109,7 +108,7 @@ These are four main functions that should serve the standard use of galario.
 
 .. function::
    void galario_chi2_profile(int nr, dreal* const ints,
-   dreal Rmin, dreal dR, dreal dxy, int nxy, dreal dist, dreal inc,
+   dreal Rmin, dreal dR, dreal dxy, int nxy, dreal inc,
    dreal dRA, dreal dDec, dreal duv, dreal PA, int nd, const dreal *u,
    const dreal *v, const dreal* fobs_re, const dreal* fobs_im,
    const dreal* weights, dreal* chi2);
@@ -187,7 +186,7 @@ Individual operations
 The following functions provide low-level access to individual operations performed by the `sample` and `chi2` functions. A standard user will likely have little use for them. Refer to the python API documentation of the wrappers for details on the individual functions.
 
 .. function::
-   void galario_sweep(int nr, dreal* ints, dreal Rmin, dreal dR, int nxy, dreal dxy, dreal dist, dreal inc, dcomplex* image);
+   void galario_sweep(int nr, dreal* ints, dreal Rmin, dreal dR, int nxy, dreal dxy, dreal inc, dcomplex* image);
 
 .. function::
    void galario_uv_rotate(dreal PA, dreal dRA, dreal dDec, dreal* dRArot, dreal* dDecrot, int nd, const dreal* u, const dreal* v, dreal* urot, dreal* vrot);

--- a/docs/C-api.rst
+++ b/docs/C-api.rst
@@ -2,59 +2,6 @@
 
 .. default-domain:: c
 
-====================
-Using galario from C
-====================
-
-The core of galario is accessible from C, all functions are in the header `galario.h`. Of course it can be used from most other languages as well, in particular C++.
-
-A small example
----------------
-
-Here is a small test program that performs the FFT in 2D on an image with random values
-
-.. literalinclude:: ../src/galario_test.c
-                    :language: c
-
-After successfully installing galario to `/path/to/galario`, a simple
-test program running galario on the CPU with `openMP` and double
-precision can be built with::
-
-  gcc -I/path/to/galario/include -L/path/to/galario/lib -lgalario -DDOUBLE_PRECISION galario_test.c -o galario_test
-
-To use single precision, simply do not define the preprocessor symbol `-DDOUBLE_PRECISION` and link in the appropriate library with `-lgalario_single`. A mismatch between the library and the preprocessor symbol causes undefined behavior but usually a segmentation fault causes the program to abort at runtime.
-
-If galario was installed with `cuda` support, link in `-lgalario_cuda` or `-lgalario_single_cuda`.
-
-Example walk-through
---------------------
-
-A small walk through the example's `main` function line by line::
-
-  galario_init();
-  ...
-  galario_cleanup();
-
-Before any computation is done inside galario, the library has to be initialized. Similarly, any data created during initialization should be cleaned at the end of `main`.
-
-To create the input image, define an array::
-
-   dreal realdata[nx*ny];
-
-The data type `dreal` can refer to either `float` or `double`, depending on the preprocessor symbol `DOUBLE_PRECISION`. galario assumes the input is a real image but the output of the FFT is complex. galario provides a helper function to allocate an array of the proper size and to copy over the input image::
-
-  dcomplex* res = galario_copy_input(nx, ny, realdata);
-
-The actual FFT is done in-place, and the result is stored in `res`. The data layout is described in the `FFTW manual <http://fftw.org/fftw3_doc/Multi_002dDimensional-DFTs-of-Real-Data.html#Multi_002dDimensional-DFTs-of-Real-Data>`_::
-
-  galario_fft2d(nx, ny, res);
-
-To deallocate `res`, we use::
-
-  galario_free(res);
-
-In general, any array created by galario and handed back to the user must be deallocated using `galario_free`.
-
 ===============
 C API reference
 ===============

--- a/docs/C-example.rst
+++ b/docs/C-example.rst
@@ -1,0 +1,56 @@
+.. http://www.sphinx-doc.org/en/stable/domains.html#the-c-domain
+
+.. default-domain:: c
+
+====================
+Using galario from C
+====================
+
+The core of galario is accessible from C, all functions are in the header `galario.h`. Of course it can be used from most other languages as well, in particular C++.
+
+A small example
+---------------
+
+Here is a small test program that performs the FFT in 2D on an image with random values
+
+.. literalinclude:: ../src/galario_test.c
+                    :language: c
+
+After successfully installing galario to `/path/to/galario`, a simple
+test program running galario on the CPU with `openMP` and double
+precision can be built with::
+
+  gcc -I/path/to/galario/include -L/path/to/galario/lib -lgalario -DDOUBLE_PRECISION galario_test.c -o galario_test
+
+To use single precision, simply do not define the preprocessor symbol `-DDOUBLE_PRECISION` and link in the appropriate library with `-lgalario_single`. A mismatch between the library and the preprocessor symbol causes undefined behavior but usually a segmentation fault causes the program to abort at runtime.
+
+If galario was installed with `cuda` support, link in `-lgalario_cuda` or `-lgalario_single_cuda`.
+
+Example walk-through
+--------------------
+
+A small walk through the example's `main` function line by line::
+
+  galario_init();
+  ...
+  galario_cleanup();
+
+Before any computation is done inside galario, the library has to be initialized. Similarly, any data created during initialization should be cleaned at the end of `main`.
+
+To create the input image, define an array::
+
+   dreal realdata[nx*ny];
+
+The data type `dreal` can refer to either `float` or `double`, depending on the preprocessor symbol `DOUBLE_PRECISION`. galario assumes the input is a real image but the output of the FFT is complex. galario provides a helper function to allocate an array of the proper size and to copy over the input image::
+
+  dcomplex* res = galario_copy_input(nx, ny, realdata);
+
+The actual FFT is done in-place, and the result is stored in `res`. The data layout is described in the `FFTW manual <http://fftw.org/fftw3_doc/Multi_002dDimensional-DFTs-of-Real-Data.html#Multi_002dDimensional-DFTs-of-Real-Data>`_::
+
+  galario_fft2d(nx, ny, res);
+
+To deallocate `res`, we use::
+
+  galario_free(res);
+
+In general, any array created by galario and handed back to the user must be deallocated using `galario_free`.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -15,7 +15,7 @@ predictions to radio interferometer observations. Namely, it speeds up the compu
 given a model image (or an axisymmetric brightness profile) and their comparison to the observations.
 
 Along with the GPU accelerated version based on the
-`CUDA Toolkit <https://developer.nvidia.com/cuda-toolkit>`_ offers a CPU counterpart accelerated with
+`CUDA Toolkit <https://developer.nvidia.com/cuda-toolkit>`_, |galario| offers a CPU counterpart accelerated with
 `openMP <http://www.openmp.org>`_.
 Modern radio interferometers like
 `ALMA <http://www.almaobservatory.org/en/home/>`_,
@@ -43,43 +43,60 @@ Basic Usage
 .. |v_j| replace:: :math:`v_j`
 .. |w_j| replace:: :math:`w_j`
 
-Let's say you have an observational dataset of `M` visibility points located at :math:`(u_j, v_j)`, with :math:`j=1...M` and |u_j|, |v_j|
-expressed in units of the observing wavelength. :math:`V_{obs\ j}` (Jy) is the :math:`j`-th complex visibility with associated theoretical weight |w_j|.
-If you want to compute the visibilities of a model `image` (Jy/px) with pixel size `dxy` (rad) in the same :math:`(u_j, v_j)` locations of the observations,
-you can easily do it with the GPU accelerated |galario|:
+Let's say you have an observational dataset of `M` visibility points located at :math:`(u_j, v_j)`, with :math:`j=1...M` and |u_j|, |v_j| expressed in units of the observing wavelength. :math:`V_{obs\ j}` (Jy) is the :math:`j`-th complex visibility with associated theoretical weight |w_j|.
+With |galario| you can:
 
-.. code-block:: python
+**1) Compute visibilities from a model image**
 
-    from galario.double_cuda import sampleImage
+    If you want to compute the visibilities of a model :code:`image` (Jy/px) with pixel size `dxy` (rad) in the same :math:`(u_j, v_j)` locations of the observations, you can easily do it with the GPU accelerated |galario|:
 
-    vis = sampleImage(image, dxy, u, v, dRA=dRA, dDec=dDec, PA=PA)
+    .. code-block:: python
 
-where `vis` is a complex array of length :math:`N` containing the real (`vis.real`) and imaginary (`vis.imag`) part of the synthetic visibilities.
-dRA, dDec and PA are optional parameters: if specified, translate the image in Right Ascension and Declination direction
-by dRA (rad) and dDec (rad), respectively, and to rotate it by a Position Angle PA (rad) (East of North).
+        from galario.double_cuda import sampleImage
 
-If you are doing a **fit** and the only number you are interested in is the **chi square** needed for the likelihood computation,
-you can use directly:
+        vis = sampleImage(image, dxy, u, v)
 
-.. code-block:: python
+    where `vis` is a complex array of length :math:`N` containing the real (`vis.real`) and imaginary (`vis.imag`) part of the synthetic visibilities.
 
-    from galario.double_cuda import chi2Image
+**2) Compute visibilities from an axisymmetric brightness profile**
 
-    chi2 = chi2Image(image, dxy, u, v, V_obs.real, V_obs.imag, w)
+    If you want to compare the observations with a model characterized by an **axisymmetric brightness profile**, |galario| offers dedicated functions that exploit the symmetry of the model to accelerate the image creation.
 
-If you want to compare the observations with a model characterized by an **axisymmetric brightness profile**, |galario| offers
-dedicated functions that exploit the symmetry of the model to accelerate the image creation.
-If :math:`I(R)` (Jy/sr) is the radial brightness profile, the command is as simple as:
+    If :math:`I(R)` (Jy/sr) is the radial brightness profile, the command is as simple as:
 
-.. code-block:: python
+    .. code-block:: python
 
-    from galario.double_cuda import sampleProfile
+        from galario.double_cuda import sampleProfile
 
-    vis = sampleProfile(I, Rmin, dR, nxy, dxy, u, v)
-.. add an example with inc, PA, dRA, dDec?
+        vis = sampleProfile(I, Rmin, dR, nxy, dxy, u, v)
 
-where `Rmin` and `dR` are expressed in radians and are the innermost radius and the cell size of the grid on which :math:`I(R)` is computed. An analogous function
-`chi2Profile` allows one to compute directly the chi square.
+    where `Rmin` and `dR` are expressed in radians and are the innermost radius and the cell size of the grid on which :math:`I(R)` is computed. An analogous function
+    `chi2Profile` allows one to compute directly the chi square.
+
+**3) Compute the** :math:`\chi^2` **of a model (image or brightness profile)**
+
+    If you are doing a **fit** and the only number you are interested in is the :math:`\chi^2` for the likelihood computation, you can use directly one of these:
+
+    .. code-block:: python
+
+        from galario.double_cuda import chi2Image
+
+        chi2 = chi2Image(image, dxy, u, v, V_obs.real, V_obs.imag, w)
+        chi2 = chi2Profile(I, Rmin, dR, nxy, dxy, u, v, V_obs.real, V_obs.imag, w)
+
+
+**4) Do all the above operations + translate and rotate the model image**
+
+    To translate the model image in Right Ascension and Declination direction by (dRA, dDec) offsets (rad),
+    or to rotate the image by a Position Angle PA (rad) (defined East of North), you can specify them as optional parameters.
+
+    This works for all the `sampleImage`, `sampleProfile`, `chi2Image` and `chi2Profile` functions:
+
+    .. code-block:: python
+
+        from galario.double_cuda import sampleImage
+
+        vis = sampleImage(image, dxy, u, v, dRA=dRA, dDec=dDec, PA=PA)
 
 .. note::
     If you work on a machine **without** a CUDA-enabled GPU, don't worry: you can use the CPU version
@@ -110,6 +127,7 @@ Contents
     cookbook
     py-api
     C-api
+    C-example
     studies
     license
 ..     quickstart

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,7 +10,7 @@
 **GPU Accelerated Library for Analysing Radio Interferometer Observations**
 ---------------------------------------------------------------------------
 
-|galario| is a toolkit that exploits the computing power of modern graphic cards (GPUs) to accelerate the comparison of model
+|galario| is a library that exploits the computing power of modern graphic cards (GPUs) to accelerate the comparison of model
 predictions to radio interferometer observations. Namely, it speeds up the computation of the synthetic visibilities
 given a model image (or an axisymmetric brightness profile) and their comparison to the observations.
 
@@ -52,9 +52,11 @@ you can easily do it with the GPU accelerated |galario|:
 
     from galario.double_cuda import sampleImage
 
-    vis = sampleImage(image, dxy, u, v)
+    vis = sampleImage(image, dxy, u, v, dRA=dRA, dDec=dDec, PA=PA)
 
 where `vis` is a complex array of length :math:`N` containing the real (`vis.real`) and imaginary (`vis.imag`) part of the synthetic visibilities.
+dRA, dDec and PA are optional parameters: if specified, translate the image in Right Ascension and Declination direction
+by dRA (rad) and dDec (rad), respectively, and to rotate it by a Position Angle PA (rad) (East of North).
 
 If you are doing a **fit** and the only number you are interested in is the **chi square** needed for the likelihood computation,
 you can use directly:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,18 +3,18 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
-=======
-galario
-=======
+=========
+|galario|
+=========
 
-**GPU Accelerated Library for Analysing Radio Interferometry Observations**
+**GPU Accelerated Library for Analysing Radio Interferometer Observations**
 ---------------------------------------------------------------------------
 
-|galario| exploits the computing power of modern graphic cards (GPUs) to accelerate the comparison of model
-predictions to the observations of radio interferometers. Namely, it speeds up the computation of the synthetic visibilities
+|galario| is a toolkit that exploits the computing power of modern graphic cards (GPUs) to accelerate the comparison of model
+predictions to radio interferometer observations. Namely, it speeds up the computation of the synthetic visibilities
 given a model image (or an axisymmetric brightness profile) and their comparison to the observations.
 
-It is licensed under LGPLv3 and along with the GPU accelerated version based on the
+Along with the GPU accelerated version based on the
 `CUDA Toolkit <https://developer.nvidia.com/cuda-toolkit>`_ offers a CPU counterpart accelerated with
 `openMP <http://www.openmp.org>`_.
 Modern radio interferometers like
@@ -31,9 +31,8 @@ relevant equations and the algorithm implementation.
 Here we do not aim to summarize the vast literature about Radio Interferometry, but we refer the interested reader to
 `this <http://aspbooks.org/a/volumes/table_of_contents/180>`_ thorough reference.
 
-|galario| is actively developed on `GitHub <https://github.com/mtazzari/galario/>`_.
-
-.. and has been employed in :doc:`these published studies <studies>`.
+|galario| is actively developed on `GitHub <https://github.com/mtazzari/galario/>`_
+and has already been employed in :doc:`these published studies <studies>`.
 
 Instructions on how to build and install |galario| can be found :doc:`here <install>`.
 
@@ -44,20 +43,16 @@ Basic Usage
 .. |v_j| replace:: :math:`v_j`
 .. |w_j| replace:: :math:`w_j`
 
-Let's say you have an observational dataset of `N` visibility points located at :math:`(u_j, v_j)`, with :math:`j=1...N` and |u_j|, |v_j|
-expressed in units of the observing wavelength. :math:`V_{obs\ j}` is the :math:`j`-th complex visibility with associated theoretical weight |w_j|.
-If you want to compute the visibilities of a model `image` in the same :math:`(u_j, v_j)` locations of the observations,
+Let's say you have an observational dataset of `M` visibility points located at :math:`(u_j, v_j)`, with :math:`j=1...M` and |u_j|, |v_j|
+expressed in units of the observing wavelength. :math:`V_{obs\ j}` (Jy) is the :math:`j`-th complex visibility with associated theoretical weight |w_j|.
+If you want to compute the visibilities of a model `image` (Jy/px) with pixel size `dxy` (rad) in the same :math:`(u_j, v_j)` locations of the observations,
 you can easily do it with the GPU accelerated |galario|:
 
 .. code-block:: python
 
-    from galario import pc, au
     from galario.double_cuda import sampleImage
 
-    dist = 240. * pc  # distance to the source [cm]
-    dxy = 10. * au    # spatial size of the pixel in the model image [cm]
-
-    vis = sampleImage(image, dxy, dist, u, v)
+    vis = sampleImage(image, dxy, u, v)
 
 where `vis` is a complex array of length :math:`N` containing the real (`vis.real`) and imaginary (`vis.imag`) part of the synthetic visibilities.
 
@@ -68,20 +63,20 @@ you can use directly:
 
     from galario.double_cuda import chi2Image
 
-    chi2 = chi2Image(image, dxy, dist, u, v, V_obs.real, V_obs.imag, w)
+    chi2 = chi2Image(image, dxy, u, v, V_obs.real, V_obs.imag, w)
 
 If you want to compare the observations with a model characterized by an **axisymmetric brightness profile**, |galario| offers
 dedicated functions that exploit the symmetry of the model to accelerate the image creation.
-If :math:`I(R)` is the radial brightness profile, the command is as simple as:
+If :math:`I(R)` (Jy/sr) is the radial brightness profile, the command is as simple as:
 
 .. code-block:: python
 
     from galario.double_cuda import sampleProfile
 
-    vis = sampleProfile(I, Rmin, dR, nxy, dxy, dist, u, v)
+    vis = sampleProfile(I, Rmin, dR, nxy, dxy, u, v)
 .. add an example with inc, PA, dRA, dDec?
 
-where `Rmin` and `dR` are the innermost radius and the cell size of the grid on which :math:`I(R)` is computed. An analogous function
+where `Rmin` and `dR` are expressed in radians and are the innermost radius and the cell size of the grid on which :math:`I(R)` is computed. An analogous function
 `chi2Profile` allows one to compute directly the chi square.
 
 .. note::
@@ -89,7 +84,7 @@ where `Rmin` and `dR` are the innermost radius and the cell size of the grid on 
     of |galario| by just removing the subscript `"_cuda"` from the imports above and benefit from the openMP parallelization.
     All the function names and interfaces are the same for GPU and CPU version!
 
-More details on how to get started with |galario| are given in the :doc:`quickstart <quickstart>`.
+.. More details on how to get started with |galario| are given in the :doc:`quickstart <quickstart>`.
 
 Be sure to checkout also the :doc:`cookbook <cookbook>` with many useful code snippets!
 
@@ -110,12 +105,12 @@ Contents
     :maxdepth: 2
 
     install
-    quickstart
     cookbook
     py-api
     C-api
+    studies
     license
-..    studies
+..     quickstart
 
 Indices
 -------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -21,8 +21,7 @@ Modern radio interferometers like
 `ALMA <http://www.almaobservatory.org/en/home/>`_,
 `VLA <https://science.nrao.edu/facilities/vla>`_,
 `NOEMA <http://www.iram-institute.org/EN/noema-project.php?ContentID=9&rub=9&srub=0&ssrub=0&sssrub=0>`_
-and the future ones like
-`SKA <http://skatelescope.org>`_ are pushing the computational efforts needed to model the observations to the extreme.
+are pushing the computational efforts needed to model the observations to the extreme.
 The unprecedented sensitivity and resolution achieved by these observatories require comparing model predictions
 with huge amount of data points that sample a wide range of spatial frequencies.
 In this context, |galario| provides a fast library useful for comparing a model to observations directly in the Fourier plane.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -28,8 +28,8 @@ In this context, |galario| provides a fast library useful for comparing a model 
 
 We presented |galario| in `Tazzari, Beaujean and Testi (2017) <LINK>`_, where you can find more details about the
 relevant equations and the algorithm implementation.
-Here we do not aim to summarize the vast literature about Radio Interferometry, but we refer the interested reader to
-`this <http://aspbooks.org/a/volumes/table_of_contents/180>`_ thorough reference.
+Here we do not aim to summarize the vast literature about Radio Interferometry, but we refer the interested reader to the
+`Synthesis Imaging in Radio Astronomy II <http://aspbooks.org/a/volumes/table_of_contents/180>`_ book.
 
 |galario| is actively developed on `GitHub <https://github.com/mtazzari/galario/>`_
 and has already been employed in :doc:`these published studies <studies>`.

--- a/docs/studies.rst
+++ b/docs/studies.rst
@@ -2,11 +2,14 @@
 Studies that used |galario|
 ===========================
 
-|galario| has been used in the following studies:
+In this page we aim to keep a record of the studies that used |galario|.
+Here is a (tentatively updated) list:
 
  - `Tazzari, Testi, Natta, et al. (2017) <https://ui.adsabs.harvard.edu/#abs/2017arXiv170701499T>`_
  - `Testi, Natta, Scholz, et al. (2016) <https://ui.adsabs.harvard.edu/#abs/2016A%26A...593A.111T>`_
  - `Tazzari, Testi, Ercolano, et al. (2016) <https://ui.adsabs.harvard.edu/#abs/2016A&A...588A..53T>`_
  - `Guidi, Tazzari, Testi, et al. (2016) <https://ui.adsabs.harvard.edu/#abs/2016A&A...588A.112G>`_
 
-If you think your paper should be added to this list, just `let us know <mtazzari@ast.cam.ac.uk>`_!
+If your paper should be added to this list, just `let us know <mtazzari@ast.cam.ac.uk>`_!
+
+Alternatively, fork the repository, edit this file by yourself and open a pull request.

--- a/docs/studies.rst
+++ b/docs/studies.rst
@@ -1,7 +1,12 @@
-======================================
-Scientific studies that used `galario`
-======================================
+===========================
+Studies that used |galario|
+===========================
 
-`galario` has been used in the following research papers:
+|galario| has been used in the following studies:
 
- - ...
+ - `Tazzari, Testi, Natta, et al. (2017) <https://ui.adsabs.harvard.edu/#abs/2017arXiv170701499T>`_
+ - `Testi, Natta, Scholz, et al. (2016) <https://ui.adsabs.harvard.edu/#abs/2016A%26A...593A.111T>`_
+ - `Tazzari, Testi, Ercolano, et al. (2016) <https://ui.adsabs.harvard.edu/#abs/2016A&A...588A..53T>`_
+ - `Guidi, Tazzari, Testi, et al. (2016) <https://ui.adsabs.harvard.edu/#abs/2016A&A...588A.112G>`_
+
+If you think your paper should be added to this list, just `let us know <mtazzari@ast.cam.ac.uk>`_!

--- a/python/libcommon.pyx
+++ b/python/libcommon.pyx
@@ -241,13 +241,13 @@ def check_obs(vis_obs_re, vis_obs_im, vis_obs_w, vis=None, u=None, v=None):
     return True
 
 
-def check_uvplane(u, v, nxy, duv, f_maxuv, f_minuv):
+def check_uvplane(u, v, nxy, duv, f_max, f_min):
     """
     Check whether the setup of the (u, v) plane satisfies Nyquist criteria for (u, v) plane sampling.
 
     Typical call signature::
 
-        check_uvplane(u, v, nxy, duv, f_maxuv, f_minuv)
+        check_uvplane(u, v, nxy, duv, f_max, f_min)
 
     Parameters
     ----------
@@ -264,25 +264,25 @@ def check_uvplane(u, v, nxy, duv, f_maxuv, f_minuv):
     duv : float
         Size of the cell in the (u, v) plane, assumed uniform and equal on both u and v directions.
         **units**: wavelength
-    f_maxuv : float
+    f_max : float
         Nyquist rate: numerical factor that ensures the Nyquist criterion is satisfied when sampling
         the synthetic visibilities at the specified (u, v) locations. Must be larger than 2.
-        The maximum (u, v)-distance covered is `f_maxuv` times the maximum (u, v)-distance
+        The maximum (u, v)-distance covered is `f_max` times the maximum (u, v)-distance
         of the observed visibilities.
         **units**: pure number
-    f_minuv : float
+    f_min : float
         Size of the field of view covered by the (u, v) plane grid w.r.t. the field
         of view covered by the image. Recommended to be larger than 3 for better results.
         **units**: pure number
 
     """
     assert len(u) == len(v), "Wrong array length: u, v must have same length."
-    assert f_maxuv > 2., "Expected f_maxuv > 2 to ensure correct Nyquist sampling."
-    assert f_minuv > 3., "Expected f_minuv > 3 to ensure the image covers the field of view of the data."
+    assert f_max > 2., "Expected f_max > 2 to ensure correct Nyquist sampling."
+    assert f_min > 3., "Expected f_min > 3 to ensure the image covers the field of view of the data."
 
     uvdist = np.hypot(u, v)
-    min_uv = np.min(uvdist)/f_minuv
-    max_uv = np.max(uvdist) * 2. * f_maxuv
+    min_uv = np.min(uvdist)/f_min
+    max_uv = np.max(uvdist) * 2. * f_max
     # the factor of 2 comes from the fact that the FFT sample frequencies from -0.5 to 0.5 times max_uv
 
     assert duv <= min_uv, "The image does not cover the full field of view of the observations: try increasing nxy or dxy."
@@ -297,7 +297,7 @@ def get_image_size(u, v, dxy=None, f_max=2.2, f_min=3.1):
 
     Typical call signature::
 
-        nxy, dxy = get_image_size(u, v, dxy=None, f_maxuv=2.2, f_minuv=3.1)
+        nxy, dxy = get_image_size(u, v, dxy=None, f_max=2.2, f_min=3.1)
 
     Parameters
     ----------
@@ -384,7 +384,7 @@ def get_uvcell_size(nxy, dxy):
 # ############################################################################ #
 
 def sampleImage(dreal[:,::1] image, dxy, dreal[::1] u, dreal[::1] v,
-                dRA=0., dDec=0., PA=0., uvcheck=False, f_minuv=3.1, f_maxuv=2.2):
+                dRA=0., dDec=0., PA=0., uvcheck=False, f_min=3.1, f_max=2.2):
     """
     Compute the synthetic visibilities of a model image at the specified (u, v) locations.
 
@@ -428,10 +428,10 @@ def sampleImage(dreal[:,::1] image, dxy, dreal[::1] u, dreal[::1] v,
         If True, check whether `image` and `dxy` satisfy Nyquist criterion for computing
         the synthetic visibilities in the (u, v) locations provided.
         Default is False since the check might take time. For executions where speed is important, set to False.
-    f_maxuv : float, optional
+    f_max : float, optional
         See :func:`.check_uvplane`.
         **units**: pure number
-    f_minuv : float, optional
+    f_min : float, optional
         See :func:`.check_uvplane`.
         **units**: pure number
 
@@ -448,7 +448,7 @@ def sampleImage(dreal[:,::1] image, dxy, dreal[::1] u, dreal[::1] v,
     duv = get_uvcell_size(nxy, dxy)
 
     if uvcheck:
-        check_uvplane(u, v, nxy, duv, f_maxuv, f_minuv)
+        check_uvplane(u, v, nxy, duv, f_max, f_min)
 
     PA *= deg
     dRA *= arcsec
@@ -461,7 +461,7 @@ def sampleImage(dreal[:,::1] image, dxy, dreal[::1] u, dreal[::1] v,
 
 
 def sampleProfile(dreal[::1] intensity, Rmin, dR, nxy, dxy, dreal[::1] u, dreal[::1] v,
-                  dRA=0., dDec=0., inc=0., PA=0., uvcheck=False, f_minuv=3.1, f_maxuv=2.2):
+                  dRA=0., dDec=0., inc=0., PA=0., uvcheck=False, f_min=3.1, f_max=2.2):
     """
     Compute the synthetic visibilities of a model with an axisymmetric brightness profile.
 
@@ -521,10 +521,10 @@ def sampleProfile(dreal[::1] intensity, Rmin, dR, nxy, dxy, dreal[::1] u, dreal[
         If True, check whether `image` and `dxy` satisfy Nyquist criterion for computing
         the synthetic visibilities in the (u, v) locations provided.
         Default is False since the check might take time. For executions where speed is important, set to False.
-    f_maxuv : float, optional
+    f_max : float, optional
         See :func:`.check_uvplane`.
         **units**: pure number
-    f_minuv : float, optional
+    f_min : float, optional
         See :func:`.check_uvplane`.
         **units**: pure number
 
@@ -543,7 +543,7 @@ def sampleProfile(dreal[::1] intensity, Rmin, dR, nxy, dxy, dreal[::1] u, dreal[
     duv = get_uvcell_size(nxy, dxy)
 
     if uvcheck:
-        check_uvplane(u, v, nxy, duv, f_maxuv, f_minuv)
+        check_uvplane(u, v, nxy, duv, f_max, f_min)
 
     PA *= deg
     inc *= deg
@@ -558,7 +558,7 @@ def sampleProfile(dreal[::1] intensity, Rmin, dR, nxy, dxy, dreal[::1] u, dreal[
 
 def chi2Image(dreal[:,::1] image, dxy, dreal[::1] u, dreal[::1] v,
               dreal[::1] vis_obs_re, dreal[::1] vis_obs_im, dreal[::1] vis_obs_w,
-              dRA=0., dDec=0., PA=0., uvcheck=False, f_minuv=3.1, f_maxuv=2.2):
+              dRA=0., dDec=0., PA=0., uvcheck=False, f_min=3.1, f_max=2.2):
     """
     Compute the chi square of a model image given the observed visibilities.
 
@@ -620,10 +620,10 @@ def chi2Image(dreal[:,::1] image, dxy, dreal[::1] u, dreal[::1] v,
         If True, check whether `image` and `dxy` satisfy Nyquist criterion for computing
         the synthetic visibilities in the (u, v) locations provided.
         Default is False since the check might take time. For executions where speed is important, set to False.
-    f_maxuv : float, optional
+    f_max : float, optional
         See :func:`.check_uvplane`.
         **units**: pure number
-    f_minuv : float, optional
+    f_min : float, optional
         See :func:`.check_uvplane`.
         **units**: pure number
 
@@ -644,7 +644,7 @@ def chi2Image(dreal[:,::1] image, dxy, dreal[::1] u, dreal[::1] v,
     duv = get_uvcell_size(nxy, dxy)
 
     if uvcheck:
-        check_uvplane(u, v, nxy, duv, f_maxuv, f_minuv)
+        check_uvplane(u, v, nxy, duv, f_max, f_min)
 
     cdef dreal chi2
     PA *= deg
@@ -658,7 +658,7 @@ def chi2Image(dreal[:,::1] image, dxy, dreal[::1] u, dreal[::1] v,
 
 def chi2Profile(dreal[::1] intensity, Rmin, dR, nxy, dxy, dreal[::1] u, dreal[::1] v,
                 dreal[::1] vis_obs_re, dreal[::1] vis_obs_im, dreal[::1] vis_obs_w,
-                dRA=0., dDec=0., inc=0., PA=0., uvcheck=False, f_minuv=3.1, f_maxuv=2.2):
+                dRA=0., dDec=0., inc=0., PA=0., uvcheck=False, f_min=3.1, f_max=2.2):
     """
     Compute the chi square of a model with an axisymmetric brightness profile
     given the observed visibilities.
@@ -734,10 +734,10 @@ def chi2Profile(dreal[::1] intensity, Rmin, dR, nxy, dxy, dreal[::1] u, dreal[::
         If True, check whether `image` and `dxy` satisfy Nyquist criterion for computing
         the synthetic visibilities in the (u, v) locations provided.
         Default is False since the check might take time. For executions where speed is important, set to False.
-    f_maxuv : float, optional
+    f_max : float, optional
         See :func:`.check_uvplane`.
         **units**: pure number
-    f_minuv : float, optional
+    f_min : float, optional
         See :func:`.check_uvplane`.
         **units**: pure number
 
@@ -757,7 +757,7 @@ def chi2Profile(dreal[::1] intensity, Rmin, dR, nxy, dxy, dreal[::1] u, dreal[::
     duv = get_uvcell_size(nxy, dxy)
 
     if uvcheck:
-        check_uvplane(u, v, nxy, duv, f_maxuv, f_minuv)
+        check_uvplane(u, v, nxy, duv, f_max, f_min)
 
     cdef dreal chi2
     inc *= deg

--- a/python/libcommon.pyx
+++ b/python/libcommon.pyx
@@ -278,7 +278,7 @@ def check_uvplane(u, v, nxy, duv, f_max, f_min):
     """
     assert len(u) == len(v), "Wrong array length: u, v must have same length."
     assert f_max > 2., "Expected f_max > 2 to ensure correct Nyquist sampling."
-    assert f_min > 3., "Expected f_min > 3 to ensure the image covers the field of view of the data."
+    assert f_min > 1., "Expected f_min > 1 to ensure the image covers the maximum recoverable scale of the data."
 
     uvdist = np.hypot(u, v)
     min_uv = np.min(uvdist)/f_min
@@ -291,13 +291,13 @@ def check_uvplane(u, v, nxy, duv, f_max, f_min):
     return True
 
 
-def get_image_size(u, v, dxy=None, f_max=2.2, f_min=3.1):
+def get_image_size(u, v, dxy=None, f_max=2.5, f_min=3.):
     """
     Compute the recommended image size given the (u, v) locations.
 
     Typical call signature::
 
-        nxy, dxy = get_image_size(u, v, dxy=None, f_max=2.2, f_min=3.1)
+        nxy, dxy = get_image_size(u, v, dxy=None, f_max=2.5, f_min=3.)
 
     Parameters
     ----------
@@ -384,7 +384,7 @@ def get_uvcell_size(nxy, dxy):
 # ############################################################################ #
 
 def sampleImage(dreal[:,::1] image, dxy, dreal[::1] u, dreal[::1] v,
-                dRA=0., dDec=0., PA=0., uvcheck=False, f_min=3.1, f_max=2.2):
+                dRA=0., dDec=0., PA=0., uvcheck=False, f_min=3., f_max=2.5):
     """
     Compute the synthetic visibilities of a model image at the specified (u, v) locations.
 
@@ -461,7 +461,7 @@ def sampleImage(dreal[:,::1] image, dxy, dreal[::1] u, dreal[::1] v,
 
 
 def sampleProfile(dreal[::1] intensity, Rmin, dR, nxy, dxy, dreal[::1] u, dreal[::1] v,
-                  dRA=0., dDec=0., inc=0., PA=0., uvcheck=False, f_min=3.1, f_max=2.2):
+                  dRA=0., dDec=0., PA=0., inc=0., uvcheck=False, f_min=3., f_max=2.5):
     """
     Compute the synthetic visibilities of a model with an axisymmetric brightness profile.
 
@@ -510,12 +510,12 @@ def sampleProfile(dreal[::1] intensity, Rmin, dR, nxy, dxy, dreal[::1] u, dreal[
         Dec. offset w.r.t. the phase center by which the image is translated.
         If dDec > 0 translate the image towards the top (North). Default is 0.
         **units**: arcsecond
+    PA : float, optional
+        Position Angle, defined East of North. Default is 0.
+        **units**: degree
     inc : float, optional
         Inclination of the image plane along a North-South (top-bottom) axis.
         If inc=0. the image is face-on; if inc=90. the image is edge-on.
-        **units**: degree
-    PA : float, optional
-        Position Angle, defined East of North. Default is 0.
         **units**: degree
     uvcheck : bool, optional
         If True, check whether `image` and `dxy` satisfy Nyquist criterion for computing
@@ -558,7 +558,7 @@ def sampleProfile(dreal[::1] intensity, Rmin, dR, nxy, dxy, dreal[::1] u, dreal[
 
 def chi2Image(dreal[:,::1] image, dxy, dreal[::1] u, dreal[::1] v,
               dreal[::1] vis_obs_re, dreal[::1] vis_obs_im, dreal[::1] vis_obs_w,
-              dRA=0., dDec=0., PA=0., uvcheck=False, f_min=3.1, f_max=2.2):
+              dRA=0., dDec=0., PA=0., uvcheck=False, f_min=3., f_max=2.5):
     """
     Compute the chi square of a model image given the observed visibilities.
 
@@ -658,7 +658,7 @@ def chi2Image(dreal[:,::1] image, dxy, dreal[::1] u, dreal[::1] v,
 
 def chi2Profile(dreal[::1] intensity, Rmin, dR, nxy, dxy, dreal[::1] u, dreal[::1] v,
                 dreal[::1] vis_obs_re, dreal[::1] vis_obs_im, dreal[::1] vis_obs_w,
-                dRA=0., dDec=0., inc=0., PA=0., uvcheck=False, f_min=3.1, f_max=2.2):
+                dRA=0., dDec=0., PA=0., inc=0., uvcheck=False, f_min=3., f_max=2.5):
     """
     Compute the chi square of a model with an axisymmetric brightness profile
     given the observed visibilities.
@@ -723,12 +723,12 @@ def chi2Profile(dreal[::1] intensity, Rmin, dR, nxy, dxy, dreal[::1] u, dreal[::
         Dec. offset w.r.t. the phase center by which the image is translated.
         If dDec > 0 translate the image towards the top (North). Default is 0.
         **units**: arcsecond
+    PA : float, optional
+        Position Angle, defined East of North. Default is 0.
+        **units**: degree
     inc : float, optional
         Inclination of the image plane along a North-South (top-bottom) axis.
         If inc=0. the image is face-on; if inc=90. the image is edge-on.
-        **units**: degree
-    PA : float, optional
-        Position Angle, defined East of North. Default is 0.
         **units**: degree
     uvcheck : bool, optional
         If True, check whether `image` and `dxy` satisfy Nyquist criterion for computing

--- a/python/libcommon.pyx
+++ b/python/libcommon.pyx
@@ -43,11 +43,11 @@ ELSE:
 
 cdef extern from "galario_py.h":
     # Main user functions
-    void _galario_sample_profile(int nr, void* intensity, dreal Rmin, dreal dR, dreal dxy, int nxy, dreal dist, dreal inc, dreal dRA, dreal dDec, dreal duv, dreal PA, int nd, void* u, void* v, void* vis)
+    void _galario_sample_profile(int nr, void* intensity, dreal Rmin, dreal dR, dreal dxy, int nxy, dreal inc, dreal dRA, dreal dDec, dreal duv, dreal PA, int nd, void* u, void* v, void* vis)
     void _galario_sample_image(int nx, int ny, void* image, dreal dRA, dreal dDec, dreal duv, dreal PA, int nd, void* u, void* v, void* vis)
-    void _galario_chi2_profile(int nr, void* intensity, dreal Rmin, dreal dR, dreal dxy, int nxy, dreal dist, dreal inc, dreal dRA, dreal dDec, dreal duv, dreal PA, int nd, void* u, void* v, void* vis_obs_re, void* vis_obs_im, void* vis_obs_w, dreal* chi2)
+    void _galario_chi2_profile(int nr, void* intensity, dreal Rmin, dreal dR, dreal dxy, int nxy, dreal inc, dreal dRA, dreal dDec, dreal duv, dreal PA, int nd, void* u, void* v, void* vis_obs_re, void* vis_obs_im, void* vis_obs_w, dreal* chi2)
     void _galario_chi2_image(int nx, int ny, void* image, dreal dRA, dreal dDec, dreal duv, dreal PA, int nd, void* u, void* v, void* vis_obs_re, void* vis_obs_im, void* vis_obs_w, dreal* chi2)
-    void _galario_sweep(int nr, void* intensity, dreal Rmin, dreal dR, int nxy, dreal dxy, dreal dist, dreal inc, void* image)
+    void _galario_sweep(int nr, void* intensity, dreal Rmin, dreal dR, int nxy, dreal dxy, dreal inc, void* image)
     void _galario_uv_rotate(dreal PA, dreal dRA, dreal dDec, void* dRArot, void* dDecrot, int nd, void* u, void* v, void* urot, void* vrot)
 
     # Interface for the experts
@@ -551,7 +551,7 @@ def sampleProfile(dreal[::1] intensity, Rmin, dR, nxy, dxy, dreal[::1] u, dreal[
     dDec *= arcsec
 
     vis = np.zeros(len(u), dtype=complex_dtype)
-    _galario_sample_profile(len(intensity), <void*>&intensity[0], Rmin, dR, dxy, nxy, 1., inc, dRA, dDec, duv, PA, len(u), <void*>&u[0], <void*>&v[0], <void*>np.PyArray_DATA(vis))
+    _galario_sample_profile(len(intensity), <void*>&intensity[0], Rmin, dR, dxy, nxy, inc, dRA, dDec, duv, PA, len(u), <void*>&u[0], <void*>&v[0], <void*>np.PyArray_DATA(vis))
 
     return vis
 
@@ -765,7 +765,7 @@ def chi2Profile(dreal[::1] intensity, Rmin, dR, nxy, dxy, dreal[::1] u, dreal[::
     dRA *= arcsec
     dDec *= arcsec
 
-    _galario_chi2_profile(len(intensity), <void*> &intensity[0], Rmin, dR, dxy, nxy, 1., inc, dRA, dDec, duv, PA, len(u), <void*> &u[0],  <void*> &v[0],  <void*>&vis_obs_re[0], <void*>&vis_obs_im[0], <void*>&vis_obs_w[0], &chi2)
+    _galario_chi2_profile(len(intensity), <void*> &intensity[0], Rmin, dR, dxy, nxy, inc, dRA, dDec, duv, PA, len(u), <void*> &u[0],  <void*> &v[0],  <void*>&vis_obs_re[0], <void*>&vis_obs_im[0], <void*>&vis_obs_w[0], &chi2)
 
     return chi2
 
@@ -819,7 +819,7 @@ def sweep(dreal[::1] intensity, Rmin, dR, nxy, dxy, inc=0.):
     inc *= deg
     image = np.empty((nxy, nxy//2+1), dtype=complex_dtype, order='C')
 
-    _galario_sweep(len(intensity), <void*>&intensity[0], Rmin, dR, nxy, dxy, 1, inc, <void*>np.PyArray_DATA(image))
+    _galario_sweep(len(intensity), <void*>&intensity[0], Rmin, dR, nxy, dxy, inc, <void*>np.PyArray_DATA(image))
 
     # return a copy so is C-Continuous and can be used in sampleImage()
     return image.view(dtype=real_dtype)[:, :-2].copy()

--- a/python/libcommon.pyx
+++ b/python/libcommon.pyx
@@ -416,14 +416,14 @@ def sampleImage(dreal[:,::1] image, dxy, dreal[::1] u, dreal[::1] v,
     dRA : float, optional
         R.A. offset w.r.t. the phase center by which the image is translated.
         If dRA > 0 translate the image towards the left (East). Default is 0.
-        **units**: arcsecond
+        **units**: rad
     dDec : float, optional
         Dec. offset w.r.t. the phase center by which the image is translated.
         If dDec > 0 translate the image towards the top (North). Default is 0.
-        **units**: arcsecond
+        **units**: rad
     PA : float, optional
         Position Angle, defined East of North. Default is 0.
-        **units**: degree
+        **units**: rad
     uvcheck : bool, optional
         If True, check whether `image` and `dxy` satisfy Nyquist criterion for computing
         the synthetic visibilities in the (u, v) locations provided.
@@ -449,10 +449,6 @@ def sampleImage(dreal[:,::1] image, dxy, dreal[::1] u, dreal[::1] v,
 
     if uvcheck:
         check_uvplane(u, v, nxy, duv, f_max, f_min)
-
-    PA *= deg
-    dRA *= arcsec
-    dDec *= arcsec
 
     vis = np.zeros(len(u), dtype=complex_dtype)
     _galario_sample_image(nxy, nxy, <void*>&image[0,0], dRA, dDec, duv, PA, len(u), <void*>&u[0], <void*>&v[0], <void*>np.PyArray_DATA(vis))
@@ -505,18 +501,18 @@ def sampleProfile(dreal[::1] intensity, Rmin, dR, nxy, dxy, dreal[::1] u, dreal[
     dRA : float, optional
         R.A. offset w.r.t. the phase center by which the image is translated.
         If dRA > 0 translate the image towards the left (East). Default is 0.
-        **units**: arcsecond
+        **units**: rad
     dDec : float, optional
         Dec. offset w.r.t. the phase center by which the image is translated.
         If dDec > 0 translate the image towards the top (North). Default is 0.
-        **units**: arcsecond
+        **units**: rad
     PA : float, optional
         Position Angle, defined East of North. Default is 0.
-        **units**: degree
+        **units**: rad
     inc : float, optional
         Inclination of the image plane along a North-South (top-bottom) axis.
         If inc=0. the image is face-on; if inc=90. the image is edge-on.
-        **units**: degree
+        **units**: rad
     uvcheck : bool, optional
         If True, check whether `image` and `dxy` satisfy Nyquist criterion for computing
         the synthetic visibilities in the (u, v) locations provided.
@@ -544,11 +540,6 @@ def sampleProfile(dreal[::1] intensity, Rmin, dR, nxy, dxy, dreal[::1] u, dreal[
 
     if uvcheck:
         check_uvplane(u, v, nxy, duv, f_max, f_min)
-
-    PA *= deg
-    inc *= deg
-    dRA *= arcsec
-    dDec *= arcsec
 
     vis = np.zeros(len(u), dtype=complex_dtype)
     _galario_sample_profile(len(intensity), <void*>&intensity[0], Rmin, dR, dxy, nxy, inc, dRA, dDec, duv, PA, len(u), <void*>&u[0], <void*>&v[0], <void*>np.PyArray_DATA(vis))
@@ -608,14 +599,14 @@ def chi2Image(dreal[:,::1] image, dxy, dreal[::1] u, dreal[::1] v,
     dRA : float, optional
         R.A. offset w.r.t. the phase center by which the image is translated.
         If dRA > 0 translate the image towards the left (East). Default is 0.
-        **units**: arcsecond
+        **units**: rad
     dDec : float, optional
         Dec. offset w.r.t. the phase center by which the image is translated.
         If dDec > 0 translate the image towards the top (North). Default is 0.
-        **units**: arcsecond
+        **units**: rad
     PA : float, optional
         Position Angle, defined East of North. Default is 0.
-        **units**: degree
+        **units**: rad
     uvcheck : bool, optional
         If True, check whether `image` and `dxy` satisfy Nyquist criterion for computing
         the synthetic visibilities in the (u, v) locations provided.
@@ -647,9 +638,6 @@ def chi2Image(dreal[:,::1] image, dxy, dreal[::1] u, dreal[::1] v,
         check_uvplane(u, v, nxy, duv, f_max, f_min)
 
     cdef dreal chi2
-    PA *= deg
-    dRA *= arcsec
-    dDec *= arcsec
 
     _galario_chi2_image(image.shape[0], image.shape[1], <void*>&image[0,0], dRA, dDec, duv, PA, len(u), <void*> &u[0],  <void*> &v[0],  <void*>&vis_obs_re[0], <void*>&vis_obs_im[0], <void*>&vis_obs_w[0], &chi2)
 
@@ -718,18 +706,18 @@ def chi2Profile(dreal[::1] intensity, Rmin, dR, nxy, dxy, dreal[::1] u, dreal[::
     dRA : float, optional
         R.A. offset w.r.t. the phase center by which the image is translated.
         If dRA > 0 translate the image towards the left (East). Default is 0.
-        **units**: arcsecond
+        **units**: rad
     dDec : float, optional
         Dec. offset w.r.t. the phase center by which the image is translated.
         If dDec > 0 translate the image towards the top (North). Default is 0.
-        **units**: arcsecond
+        **units**: rad
     PA : float, optional
         Position Angle, defined East of North. Default is 0.
-        **units**: degree
+        **units**: rad
     inc : float, optional
         Inclination of the image plane along a North-South (top-bottom) axis.
         If inc=0. the image is face-on; if inc=90. the image is edge-on.
-        **units**: degree
+        **units**: rad
     uvcheck : bool, optional
         If True, check whether `image` and `dxy` satisfy Nyquist criterion for computing
         the synthetic visibilities in the (u, v) locations provided.
@@ -760,10 +748,6 @@ def chi2Profile(dreal[::1] intensity, Rmin, dR, nxy, dxy, dreal[::1] u, dreal[::
         check_uvplane(u, v, nxy, duv, f_max, f_min)
 
     cdef dreal chi2
-    inc *= deg
-    PA *= deg
-    dRA *= arcsec
-    dDec *= arcsec
 
     _galario_chi2_profile(len(intensity), <void*> &intensity[0], Rmin, dR, dxy, nxy, inc, dRA, dDec, duv, PA, len(u), <void*> &u[0],  <void*> &v[0],  <void*>&vis_obs_re[0], <void*>&vis_obs_im[0], <void*>&vis_obs_w[0], &chi2)
 
@@ -804,7 +788,7 @@ def sweep(dreal[::1] intensity, Rmin, dR, nxy, dxy, inc=0.):
     inc : float, optional
         Inclination of the image plane along a North-South (top-bottom) axis.
         If inc=0. the image is face-on; if inc=90. the image is edge-on.
-        **units**: degree
+        **units**: rad
 
     Returns
     -------
@@ -816,7 +800,6 @@ def sweep(dreal[::1] intensity, Rmin, dR, nxy, dxy, inc=0.):
     assert Rmin < dxy, "For the interpolation algorithm, Rmin must be smaller than dxy. " \
                        "Currently Rmin={}\t dxy={}".format(Rmin, dxy)
 
-    inc *= deg
     image = np.empty((nxy, nxy//2+1), dtype=complex_dtype, order='C')
 
     _galario_sweep(len(intensity), <void*>&intensity[0], Rmin, dR, nxy, dxy, inc, <void*>np.PyArray_DATA(image))
@@ -838,13 +821,13 @@ def uv_rotate(PA, dRA, dDec, dreal[::1] u, dreal[::1] v):
     ----------
     PA : float
         Position Angle, defined East of North.
-        **units**: degree
+        **units**: rad
     dRA : float, optional
         R.A. offset.
-        **units**: arcsecond
+        **units**: rad
     dDec : float, optional
         Dec. offset.
-        **units**: arcsecond
+        **units**: rad
     u : array_like, float
         u coordinate of the visibility points.
         **units**: wavelength
@@ -867,8 +850,6 @@ def uv_rotate(PA, dRA, dDec, dreal[::1] u, dreal[::1] v):
     """
     nd = len(u)
     assert nd == len(v)
-
-    PA *= deg
 
     cdef dreal dRArot
     cdef dreal dDecrot
@@ -933,10 +914,10 @@ def apply_phase_vis(dRA, dDec, dreal[::1] u, dreal[::1] v, dcomplex[::1] vis):
     ----------
     dRA : float
         Right Ascension offset.
-        **units**: arcseconds
+        **units**: rad
     dDec : float
         Declination offset.
-        **units**: arcseconds
+        **units**: rad
     u : array_like, float
         u-coordinates of visibility points.
         **units**: observing wavelength
@@ -954,9 +935,6 @@ def apply_phase_vis(dRA, dDec, dreal[::1] u, dreal[::1] v, dcomplex[::1] vis):
         **units**: arbitrary, same as vis
 
     """
-    dRA *= arcsec
-    dDec *= arcsec
-
     vis_out = np.copy(vis, order='C')
     _galario_apply_phase_sampled(dRA, dDec, len(vis), <void*> &u[0], <void*> &v[0], <void*>np.PyArray_DATA(vis_out))
 

--- a/python/speed_benchmark.py
+++ b/python/speed_benchmark.py
@@ -4,12 +4,8 @@ from __future__ import (division, print_function, absolute_import,
                         unicode_literals)
 
 import numpy as np
-import os
 import datetime
-import textwrap
 import timeit
-import optparse
-import sys
 
 from utils import generate_random_vis, create_reference_image, create_sampling_points
 import galario

--- a/python/speed_benchmark.py
+++ b/python/speed_benchmark.py
@@ -71,18 +71,17 @@ def setup_chi2Image(nxy, nsamples):
     dDec = 2.5
     PA = 80.
 
-    dist = 130. * pc
     maxuv_generator = 3e3
     udat, vdat = create_sampling_points(nsamples, maxuv_generator, dtype='float64')
     x, _, w = generate_random_vis(nsamples, options.dtype)
 
     _, _, maxuv = matrix_size(udat, vdat)
-    dxy = dist / maxuv
+    dxy = 1 / maxuv
 
     # create model image (it happens to have 0 imaginary part)
     image_ref = create_reference_image(size=nxy, kernel='gaussian', dtype=options.dtype)
 
-    return image_ref, dxy, dist, udat, vdat, x.real.copy(), x.imag.copy(), w, dRA, dDec, PA
+    return image_ref, dxy, udat, vdat, x.real.copy(), x.imag.copy(), w, dRA, dDec, PA
 
 
 def setup_chi2Profile(nxy, nsamples):
@@ -102,19 +101,17 @@ def setup_chi2Profile(nxy, nsamples):
     udat, vdat = create_sampling_points(nsamples, maxuv_generator, dtype=options.dtype)
     x, _, w = generate_random_vis(nsamples, options.dtype)
 
-    dist = 130. * pc
-
     _, _, maxuv = matrix_size(udat, vdat)
     maxuv /= wle_m
-    dxy = dist / maxuv
+    dxy = 1 / maxuv
 
     # compute the matrix size and maxuv
-    # nxy, dxy = g_double.get_image_size(dist, udat/wle_m, vdat/wle_m)
+    # nxy, dxy = g_double.get_image_size(udat/wle_m, vdat/wle_m)
 
     # compute radial profile
     ints = radial_profile(Rmin, dR, nrad, profile_mode, dtype=options.dtype, gauss_width=150.)
 
-    return ints, Rmin, dR, nxy, dxy, dist, udat/wle_m, vdat/wle_m, x.real.copy(), x.imag.copy(), w, dRA, dDec, inc, PA
+    return ints, Rmin, dR, nxy, dxy, udat/wle_m, vdat/wle_m, x.real.copy(), x.imag.copy(), w, dRA, dDec, inc, PA
 
 def do_timing(options, input_data, gpu=False, tpb=0, omp_num_threads=0):
     if gpu:

--- a/python/test_galario.py
+++ b/python/test_galario.py
@@ -83,14 +83,15 @@ def test_intensity_sweep(Rmin, dR, nrad, nxy, dxy, inc, profile_mode, real_type)
 
 
 @pytest.mark.parametrize("nsamples, real_type, rtol, atol, acc_lib, pars",
-                          [(10, 'float64', 1e-6, 0, g_double, par1),
-                          (10, 'float64',  1e-8, 0, g_double, par2),
-                          (10, 'float64',  1e-8, 0, g_double, par3),
-                          (10, 'float64',  1e-8, 0, g_double, par4)],
+                          [(1000, 'float64', 1e-6, 0, g_double, par1),
+                          (1000, 'float64',  1e-6, 0, g_double, par2),
+                          (1000, 'float64',  1e-6, 0, g_double, par3),
+                          (1000, 'float64',  1e-6, 0, g_double, par4)],
                          ids=["{}".format(i) for i in range(4)])
 def test_R2C_vs_C2C(nsamples, real_type, rtol, atol, acc_lib, pars):
     """
     Test the (current) R2C implementation against the (old) C2C one.
+    # it is possible that 0.0002% of points differ at rtol>1e-5
 
     """
     dRA = pars['dRA']
@@ -134,8 +135,9 @@ def test_R2C_vs_C2C(nsamples, real_type, rtol, atol, acc_lib, pars):
     dxy = 1./nxy/du
     vis_galario = acc_lib.sampleImage(ref_real, dxy, udat, vdat, dRA=dRA, dDec=dDec, PA=PA)
 
+    # check python c2c vs galario
     assert_allclose(vis_galario.real, vis_c2c_shifted.real, rtol, atol)
-    assert_allclose(vis_galario.imag, vis_c2c_shifted.imag, rtol, atol)
+    assert_allclose(vis_galario.imag, vis_c2c_shifted.imag, rtol, np.abs(np.mean(vis_galario.real))*rtol)
 
 
 # single precision less precise if code compiled with `-ffast-math`, otherwise rtol=1e-7 passes
@@ -308,10 +310,10 @@ def test_reduce_chi2(nsamples, real_type, tol, acc_lib):
 
 
 @pytest.mark.parametrize("nsamples, real_type, rtol, atol, acc_lib, pars",
-                          [(int(1e2), 'float64', 1e-6, 0, g_double, par1),
-                          (int(1e2), 'float64', 1e-6, 0, g_double, par2),
-                          (int(1e2), 'float64', 1e-6, 0, g_double, par3),
-                          (int(1e2), 'float64', 1e-6, 0, g_double, par4)],
+                          [(int(1e3), 'float64', 1e-6, 0, g_double, par1),
+                          (int(1e3), 'float64', 1e-6, 0, g_double, par2),
+                          (int(1e3), 'float64', 1e-6, 0, g_double, par3),
+                          (int(1e3), 'float64', 1e-6, 0, g_double, par4)],
                          ids=["{}".format(i) for i in range(4)])
 def test_all(nsamples, real_type, rtol, atol, acc_lib, pars):
     """
@@ -365,7 +367,7 @@ def test_all(nsamples, real_type, rtol, atol, acc_lib, pars):
 
     # cross-check galario sampleProfile vs sampleImage
     assert_allclose(vis_g_sampleImage.real, vis_g_sampleProfile.real, rtol=rtol, atol=atol)
-    assert_allclose(vis_g_sampleImage.imag, vis_g_sampleProfile.imag, rtol=rtol, atol=np.abs(np.mean(vis_g_sampleProfile.real))*1.e-6)
+    assert_allclose(vis_g_sampleImage.imag, vis_g_sampleProfile.imag, rtol=rtol, atol=np.abs(np.mean(vis_g_sampleProfile.real))*rtol)
 
     # test chi2Image
     x, _, w = generate_random_vis(nsamples, real_type)

--- a/python/utils.py
+++ b/python/utils.py
@@ -6,7 +6,6 @@ from __future__ import (division, print_function, absolute_import, unicode_liter
 import numpy as np
 
 from scipy.interpolate import interp1d, RectBivariateSpline
-from galario import arcsec, pc, au, deg
 
 __all__ = ["py_sampleImage", "py_sampleProfile", "py_chi2Profile", "py_chi2Image",
            "radial_profile", "g_sweep_prototype", "sweep_ref",
@@ -16,17 +15,17 @@ __all__ = ["py_sampleImage", "py_sampleProfile", "py_chi2Profile", "py_chi2Image
            "unique_part", "assert_allclose", "apply_rotation"]
 
 
-def py_sampleImage(reference_image, dxy, udat, vdat, PA=0., dRA=0., dDec=0.):
+def py_sampleImage(reference_image, dxy, udat, vdat, dRA=0., dDec=0., PA=0.):
     """
     Python implementation of sampleImage.
 
     """
     nxy = reference_image.shape[0]
 
-    PA *= deg
-    dRA *= 2.*np.pi * arcsec
-    dDec *= 2.*np.pi * arcsec
-    du = 1. / nxy / dxy
+    dRA *= 2.*np.pi
+    dDec *= 2.*np.pi
+
+    du = 1. / (nxy*dxy)
 
     # Real to Complex transform
     fft_r2c_shifted = np.fft.fftshift(
@@ -72,12 +71,11 @@ def py_sampleImage(reference_image, dxy, udat, vdat, PA=0., dRA=0., dDec=0.):
     return vis
 
 
-def py_sampleProfile(intensity, Rmin, dR, nxy, dxy, udat, vdat, inc=0., PA=0, dRA=0., dDec=0.):
+def py_sampleProfile(intensity, Rmin, dR, nxy, dxy, udat, vdat, dRA=0., dDec=0., PA=0, inc=0.):
     """
     Python implementation of sampleProfile.
 
     """
-    inc *= deg
     inc_cos = np.cos(inc)
 
     nrad = len(intensity)
@@ -110,7 +108,7 @@ def py_sampleProfile(intensity, Rmin, dR, nxy, dxy, udat, vdat, inc=0., PA=0, dR
     return vis
 
 
-def py_chi2Image(reference_image, dxy, udat, vdat, vis_obs_re, vis_obs_im, weights, PA=0., dRA=0., dDec=0.):
+def py_chi2Image(reference_image, dxy, udat, vdat, vis_obs_re, vis_obs_im, weights, dRA=0., dDec=0., PA=0.):
     """
     Python implementation of chi2Image.
 
@@ -123,7 +121,7 @@ def py_chi2Image(reference_image, dxy, udat, vdat, vis_obs_re, vis_obs_im, weigh
 
 
 
-def py_chi2Profile(intensity, Rmin, dR, nxy, dxy, udat, vdat, vis_obs_re, vis_obs_im, weights, inc=0., PA=0, dRA=0., dDec=0.):
+def py_chi2Profile(intensity, Rmin, dR, nxy, dxy, udat, vdat, vis_obs_re, vis_obs_im, weights, dRA=0., dDec=0., PA=0, inc=0.):
     """
     Python implementation of chi2Profile.
 
@@ -204,7 +202,6 @@ def sweep_ref(I, Rmin, dR, nrow, ncol, dxy, inc, Dx=0., Dy=0., dtype_image='floa
         Image of the disk, i.e. the intensity map.
 
     """
-    inc = inc/180.*np.pi
     inc_cos = np.cos(inc)
 
     nrad = len(I)
@@ -350,7 +347,7 @@ def apply_phase_array(u, v, fint, x0, y0):
     fint: 1D float array, complex
         Fourier Transform sampled in the (u, v) points.
         Re, Im, u, v must have the same length.
-    x0, y0: floats, arcsec
+    x0, y0: floats, rad
         Shifts in the real space.
 
     Returns
@@ -359,10 +356,6 @@ def apply_phase_array(u, v, fint, x0, y0):
         Phase-shifted of the Fourier Transform sampled in the (u, v) points.
 
     """
-    # convert x0, y0 from arcsec to cm
-    x0 *= arcsec
-    y0 *= arcsec
-
     x0 *= 2.*np.pi
     y0 *= 2.*np.pi
 
@@ -389,9 +382,8 @@ def generate_random_vis(nsamples, dtype):
 
 def apply_rotation(PA, dRA, dDec, udat, vdat):
     """ Rotates the RA, Dec offsets and the udat and vdat coordinates by Position Angle PA """
-    # PA: deg
+    # PA: rad
 
-    PA = PA / 180. * np.pi
     cos_PA = np.cos(PA)
     sin_PA = np.sin(PA)
 

--- a/src/galario.cpp
+++ b/src/galario.cpp
@@ -770,7 +770,7 @@ inline void apply_phase_sampled_core(int const idx_x, const dreal* const u, cons
 #ifdef __CUDACC__
 __global__ void apply_phase_sampled_d(dreal dRA, dreal dDec, int const nd, const dreal* const u, const dreal* const v, dcomplex* __restrict__ fint) {
 
-    if ((dRA==0) || (dDec==0)) {
+    if ((dRA==0.) && (dDec==0.)) {
         return;
     }
 
@@ -791,7 +791,7 @@ __global__ void apply_phase_sampled_d(dreal dRA, dreal dDec, int const nd, const
 
 void apply_phase_sampled_h(dreal dRA, dreal dDec, int const nd, const dreal* const u, const dreal* const v, dcomplex* const __restrict__ fint) {
 
-    if ((dRA==0) || (dDec==0)) {
+    if ((dRA==0.) && (dDec==0.)) {
         return;
     }
 
@@ -874,7 +874,7 @@ void uv_rotate_h(dreal PA, dreal dRA, dreal dDec, dreal* dRArot, dreal* dDecrot,
                  dreal* const urot, dreal* vrot) {
     CPUTimer t;
 
-    if (PA==0) {
+    if (PA==0.) {
         *dRArot = dRA;
         *dDecrot = dDec;
         memcpy(urot, u, sizeof(dreal)*nd);
@@ -912,7 +912,7 @@ void galario_uv_rotate(dreal PA, dreal dRA, dreal dDec, dreal* dRArot, dreal* dD
      CCheck(cudaMalloc(&urot_d, nbytes_d_dreal));
      CCheck(cudaMalloc(&vrot_d, nbytes_d_dreal));
 
-     if (PA==0) {
+     if (PA==0.) {
         *dRArot = dRA;
         *dDecrot = dDec;
         cudaMemcpy(urot_d, u_d, nbytes_d_dreal, cudaMemcpyDeviceToDevice);
@@ -1148,7 +1148,7 @@ inline void sample_d(int nx, int ny, dcomplex* data_d, dreal dRA, dreal dDec, in
     // ########### KERNELS ############
     // ################################
     // rotate uv points
-     if (PA==0) {
+     if (PA==0.) {
         dRArot = dRA;
         dDecrot = dDec;
         cudaMemcpy(urot_d, u_d, nbytes_ndat, cudaMemcpyDeviceToDevice);

--- a/src/galario.h
+++ b/src/galario.h
@@ -7,14 +7,14 @@ extern "C"
 {
 #endif /* __cplusplus */
     /* Main user functions */
-    void galario_sample_profile(int nr, dreal* const ints, dreal Rmin, dreal dR, dreal dxy, int nxy, dreal dist, dreal inc,
-                                dreal dRA, dreal dDec, dreal duv, dreal PA, int nd, const dreal *u, const dreal *v, dcomplex *fint);
+    void galario_sample_profile(int nr, dreal *const ints, dreal Rmin, dreal dR, dreal dxy, int nxy, dreal inc, dreal dRA,
+                                dreal dDec, dreal duv, dreal PA, int nd, const dreal *u, const dreal *v, dcomplex *fint);
     void galario_sample_image(int nx, int ny, const dreal* image, dreal dRA, dreal dDec, dreal duv, dreal PA, int nd, const dreal* u, const dreal* v, dcomplex* fint);
-    void galario_chi2_profile(int nr, dreal* const ints, dreal Rmin, dreal dR, dreal dxy, int nxy, dreal dist, dreal inc,
-                              dreal dRA, dreal dDec, dreal duv, dreal PA, int nd, const dreal *u, const dreal *v,
-                              const dreal* fobs_re, const dreal* fobs_im, const dreal* weights, dreal* chi2);
+    void galario_chi2_profile(int nr, dreal *const ints, dreal Rmin, dreal dR, dreal dxy, int nxy, dreal inc, dreal dRA,
+                                  dreal dDec, dreal duv, dreal PA, int nd, const dreal *u, const dreal *v, const dreal *fobs_re,
+                                  const dreal *fobs_im, const dreal *weights, dreal *chi2);
     void galario_chi2_image(int nx, int ny, const dreal* image, dreal dRA, dreal dDec, dreal duv, dreal PA, int nd, const dreal* u, const dreal* v, const dreal* fobs_re, const dreal* fobs_im, const dreal* weights, dreal* chi2);
-    void galario_sweep(int nr, dreal* ints, dreal Rmin, dreal dR, int nxy, dreal dxy, dreal dist, dreal inc, dcomplex* image);
+    void galario_sweep(int nr, dreal *const ints, dreal Rmin, dreal dR, int nxy, dreal dxy, dreal inc, dcomplex *image);
     void galario_uv_rotate(dreal PA, dreal dRA, dreal dDec, dreal* dRArot, dreal* dDecrot, int nd, const dreal* u, const dreal* v, dreal* urot, dreal* vrot);
 
     /* Interface for the experts */

--- a/src/galario_py.h
+++ b/src/galario_py.h
@@ -7,11 +7,14 @@
  */
 
 /* Main user functions */
-void _galario_sample_profile(int nr, void* ints, dreal Rmin, dreal dR, dreal dxy, int nxy, dreal dist, dreal inc, dreal dRA, dreal dDec, dreal duv, dreal PA, int nd, void* u, void* v, void* fint);
+void _galario_sample_profile(int nr, void *ints, dreal Rmin, dreal dR, dreal dxy, int nxy, dreal inc, dreal dRA, dreal dDec,
+                             dreal duv, dreal PA, int nd, void *u, void *v, void *fint);
 void _galario_sample_image(int nx, int ny, void* data, dreal dRA, dreal dDec, dreal duv, dreal PA, int nd, void* u, void* v, void* fint);
-void _galario_chi2_profile(int nr, void* ints, dreal Rmin, dreal dR, dreal dxy, int nxy, dreal dist, dreal inc, dreal dRA, dreal dDec, dreal duv, dreal PA, int nd, void* u, void* v, void* fobs_re, void* fobs_im, void* weights, dreal* chi2);
+void _galario_chi2_profile(int nr, void *ints, dreal Rmin, dreal dR, dreal dxy, int nxy, dreal inc, dreal dRA, dreal dDec,
+                           dreal duv, dreal PA, int nd, void *u, void *v, void *fobs_re, void *fobs_im, void *weights,
+                           dreal *chi2);
 void _galario_chi2_image(int nx, int ny, void* data, dreal dRA, dreal dDec, dreal duv, dreal PA, int nd, void* u, void* v, void* fobs_re, void* fobs_im, void* weights, dreal* chi2);
-void _galario_sweep(int nr, void* ints, dreal Rmin, dreal dR, int nxy, dreal dxy, dreal dist, dreal inc, void* image);
+void _galario_sweep(int nr, void *ints, dreal Rmin, dreal dR, int nxy, dreal dxy, dreal inc, void *image);
 void _galario_uv_rotate(dreal PA, dreal dRA, dreal dDec, void* dRArot, void* dDecrot, int nd, void* u, void* v, void* urot, void* vrot);
 
 /* Interface for the experts */


### PR DESCRIPTION
Following #85 there is no need to use linear distances in galario.
In this branch I removed all the occurrences of `dist` and now `dxy`, `dR`, `Rmin` are in radians.

One last thing I would like to do is change `dRA`, `dDec`, `inc`, `PA` also to be in radians.