### PR TITLE
Fix memory leak in cublas_handle()

### DIFF
--- a/src/galario.cpp
+++ b/src/galario.cpp
@@ -141,6 +141,7 @@ namespace {
         static cublasHandle_t handle;
         if (!initialized)
             CBlasCheck(cublasCreate(&handle));
+            initialized = true;
         return handle;
     }
 }

--- a/src/galario.cpp
+++ b/src/galario.cpp
@@ -139,9 +139,10 @@ namespace {
     cublasHandle_t& cublas_handle() {
         static bool initialized = false;
         static cublasHandle_t handle;
-        if (!initialized)
+        if (!initialized) {
             CBlasCheck(cublasCreate(&handle));
             initialized = true;
+        }
         return handle;
     }
 }


### PR DESCRIPTION
This PR solves a memory leak in the cublas_handle() definition. 
The memory leak only affected the GPU version.