### PR TITLE
[pyx] Check invalid uv indices to avoid segfaults

### DIFF
--- a/docs/C-api.rst
+++ b/docs/C-api.rst
@@ -85,6 +85,14 @@ These are four main functions that should serve the standard use of galario.
    For details, see :py:func:`chi2Image`, :func:`galario_sample_image`
    and :func:`galario_chi2_profile`.
 
+.. DANGER::
+
+   The values of `duv` and and `u`, `v` have to be consistent; i.e., :math:`\max
+   |u| \leq \frac{n}{2} + 1` and :math:`v \leq \frac{n}{2}`, where :math:`n` is
+   the number of rows and columns of the real input image. For performance
+   reasons, the interpolate function does not check this. Inconsistent values
+   may lead to segfaults.
+
 Management functions
 --------------------
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -376,6 +376,10 @@ If you still have problems, remove the `CMakeCache.txt`, rerun
 The |galario| library needs to be imported when building the documentation (the
 import would fail otherwise) to extract docstrings.
 
+To delete the sphinx cache in case the docs don't update as expected
+
+    rm -rf docs/_doctrees/
+
 .. _install_details:
 
 Install

--- a/docs/py-api.rst
+++ b/docs/py-api.rst
@@ -25,9 +25,10 @@ To compute the synthetic visibilities of a model use the :func:`sampleImage() <g
     The offset is achieved by applying a complex phase to the sampled visibilities.
     To rotation is achieved by internally rotating the (u, v) locations by -PA.
 
-    **Suggestion** We recommend starting with `uvcheck` set to True to ensure the results obtained are correct.
-    Once a combination of matrix size and `dxy` for the given data has been found, `uvcheck`
-    can be safely set to False.
+    **Suggestion**: We recommend starting with `check` set to `True` to ensure
+    the results obtained are correct. Once a combination of matrix size and
+    `dxy` for the given data has been found, `uvcheck` can be safely set to
+    `False`.
 
 Computing directly the chi square
 ---------------------------------
@@ -41,9 +42,9 @@ GPU related
 -----------
 .. py:data:: galario.HAVE_CUDA
 
-    Global variable (bool).
-    It is `True` if the GPU libraries (`galario.double_cuda` and `galario.single_cuda`) are available, `False` otherwise.
-    On a machine without a CUDA-enabled GPU it is always `False`.
+    Global variable (`bool`). It is `True` if the GPU libraries
+    (`galario.double_cuda` and `galario.single_cuda`) are available, `False`
+    otherwise. On a machine without a CUDA-enabled GPU it is always `False`.
 
 .. autofunction:: galario.double.ngpus
 .. autofunction:: galario.double.use_gpu
@@ -55,4 +56,3 @@ Other useful functions
 .. autofunction:: galario.double.check_image_size
 .. autofunction:: galario.double.sweep
 .. autofunction:: galario.double.apply_phase_vis
-

--- a/python/libcommon.pyx
+++ b/python/libcommon.pyx
@@ -241,7 +241,7 @@ def check_obs(vis_obs_re, vis_obs_im, vis_obs_w, vis=None, u=None, v=None):
     return True
 
 
-def check_image_size(u, v, nxy, dxy, PB=0, verbose=False):
+def check_image_size(u, v, nxy, dxy, duv, PB=0, verbose=False):
     """
     Check whether the setup of the (u, v) plane satisfies Nyquist criteria for (u, v) plane sampling.
 
@@ -298,6 +298,10 @@ def check_image_size(u, v, nxy, dxy, PB=0, verbose=False):
 
     if PB != 0:
         assert FOV_to_PB > 1, FOV_to_PB_str
+
+    # to avoid segfaults in the interpolation, ensure that indices are ok
+    assert np.max(np.abs(u) / duv <= nxy//2 + 1)
+    assert np.max(np.abs(v) / duv <= nxy//2)
 
     return True
 
@@ -441,7 +445,7 @@ def sampleImage(dreal[:,::1] image, dxy, dreal[::1] u, dreal[::1] v,
     duv = 1 / (dxy*nxy)
 
     if check:
-        check_image_size(u, v, nxy, dxy)
+        check_image_size(u, v, nxy, dxy, duv)
 
     vis = np.zeros(len(u), dtype=complex_dtype)
     _galario_sample_image(nxy, nxy, <void*>&image[0,0], dRA, dDec, duv, PA, len(u), <void*>&u[0], <void*>&v[0], <void*>np.PyArray_DATA(vis))
@@ -526,7 +530,7 @@ def sampleProfile(dreal[::1] intensity, Rmin, dR, nxy, dxy, dreal[::1] u, dreal[
     duv = 1 / (dxy*nxy)
 
     if check:
-        check_image_size(u, v, nxy, dxy)
+        check_image_size(u, v, nxy, dxy, duv)
 
     vis = np.zeros(len(u), dtype=complex_dtype)
     _galario_sample_profile(len(intensity), <void*>&intensity[0], Rmin, dR, dxy, nxy, inc, dRA, dDec, duv, PA, len(u), <void*>&u[0], <void*>&v[0], <void*>np.PyArray_DATA(vis))
@@ -616,7 +620,7 @@ def chi2Image(dreal[:,::1] image, dxy, dreal[::1] u, dreal[::1] v,
     duv = 1 / (dxy*nxy)
 
     if check:
-        check_image_size(u, v, nxy, dxy)
+        check_image_size(u, v, nxy, dxy, duv)
 
     cdef dreal chi2
 
@@ -720,7 +724,7 @@ def chi2Profile(dreal[::1] intensity, Rmin, dR, nxy, dxy, dreal[::1] u, dreal[::
     duv = 1 / (dxy*nxy)
 
     if check:
-        check_image_size(u, v, nxy, dxy)
+        check_image_size(u, v, nxy, dxy, duv)
 
     cdef dreal chi2
 

--- a/python/libcommon.pyx
+++ b/python/libcommon.pyx
@@ -428,9 +428,11 @@ def sampleImage(dreal[:,::1] image, dxy, dreal[::1] u, dreal[::1] v,
         Position Angle, defined East of North. Default is 0.
         **units**: rad
     check : bool, optional
-        If True, check whether `image` and `dxy` satisfy Nyquist criterion for computing
-        the synthetic visibilities in the (u, v) locations provided.
-        Default is False since the check might take time. For executions where speed is important, set to False.
+        If True, check whether `image` and `dxy` satisfy Nyquist criterion for
+        computing the synthetic visibilities in the (u, v) locations provided.
+        Additionally check that the (u, v) points fall in the image to avoid
+        segmentation violations. Default is False since the check might take
+        time. For executions where speed is important, set to False.
 
     Returns
     -------
@@ -511,9 +513,11 @@ def sampleProfile(dreal[::1] intensity, Rmin, dR, nxy, dxy, dreal[::1] u, dreal[
         If inc=0. the image is face-on; if inc=90. the image is edge-on.
         **units**: rad
     check : bool, optional
-        If True, check whether `image` and `dxy` satisfy Nyquist criterion for computing
-        the synthetic visibilities in the (u, v) locations provided.
-        Default is False since the check might take time. For executions where speed is important, set to False.
+        If True, check whether `image` and `dxy` satisfy Nyquist criterion for
+        computing the synthetic visibilities in the (u, v) locations provided.
+        Additionally check that the (u, v) points fall in the image to avoid
+        segmentation violations. Default is False since the check might take
+        time. For executions where speed is important, set to False.
 
     Returns
     -------
@@ -599,9 +603,11 @@ def chi2Image(dreal[:,::1] image, dxy, dreal[::1] u, dreal[::1] v,
         Position Angle, defined East of North. Default is 0.
         **units**: rad
     check : bool, optional
-        If True, check whether `image` and `dxy` satisfy Nyquist criterion for computing
-        the synthetic visibilities in the (u, v) locations provided.
-        Default is False since the check might take time. For executions where speed is important, set to False.
+        If True, check whether `image` and `dxy` satisfy Nyquist criterion for
+        computing the synthetic visibilities in the (u, v) locations provided.
+        Additionally check that the (u, v) points fall in the image to avoid
+        segmentation violations. Default is False since the check might take
+        time. For executions where speed is important, set to False.
 
     Returns
     -------
@@ -704,9 +710,11 @@ def chi2Profile(dreal[::1] intensity, Rmin, dR, nxy, dxy, dreal[::1] u, dreal[::
         If inc=0. the image is face-on; if inc=90. the image is edge-on.
         **units**: rad
     check : bool, optional
-        If True, check whether `image` and `dxy` satisfy Nyquist criterion for computing
-        the synthetic visibilities in the (u, v) locations provided.
-        Default is False since the check might take time. For executions where speed is important, set to False.
+        If True, check whether `image` and `dxy` satisfy Nyquist criterion for
+        computing the synthetic visibilities in the (u, v) locations provided.
+        Additionally check that the (u, v) points fall in the image to avoid
+        segmentation violations. Default is False since the check might take
+        time. For executions where speed is important, set to False.
 
     Returns
     -------


### PR DESCRIPTION
No checks done inside C++. Checks are optional and off by default in python. Adresses #114 

Please check on the gpu as usual