### PR TITLE
Add FAQs page to docs and fix contiguous arrays error

### DIFF
--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -38,11 +38,11 @@ and I get the following error:
   File "stringsource", line 348, in View.MemoryView.memoryview.__cinit__
   ValueError: ndarray is not C-contiguous
 
-The issue is caused by the arrays `u`, `v`, `Re`, `Im`, `w` being not C-contiguous, which is a requirement for the C++ code in GALARIO. You can check whether a NumPy array `x` is C-contiguous by printing `x.flags`.
+The issue is caused by one of the arrays passed in input to `chi2Profile` being not C-contiguous, which is a requirement for the C++ code in GALARIO. You can check whether a NumPy array `x` is C-contiguous by printing `x.flags`. The first action to debug this issue is to print the flags fo all the arrays in input to the function.
 
-The `u`, `v`, `Re`, `Im`, `w` arrays are usually not C-contiguous if you read them, e.g., from an ASCII uvtable with a `np.loadtxt()` command and the `unpack=True` option (or something equivalent).
+Typically this happens with the `u`, `v`, `Re`, `Im`, `w` arrays that are not C-contiguous if you read them, e.g., from an ASCII uvtable with a `np.loadtxt()` command and the `unpack=True` option (or something equivalent).
 
-**SOLUTION:** Make the arrays C-contiguous with `np.ascontiguousarray()` command:
+**SOLUTION:** Make the arrays C-contiguous with the `np.ascontiguousarray()` command. Applying this to the example:
 
 .. code-block:: python
 

--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -1,0 +1,88 @@
+.. :FAQ:
+
+.. default-role:: code
+.. role:: bash(code)
+   :language: bash
+
+.. _FAQ:
+
+=================================================
+|galario| Frequently Asked Questions with Answers
+=================================================
+
+This is the list of Frequently Asked Questions about |galario|. The list will be updated regularly to include the questions about recurring issues and relative solutions.
+
+In all the code snippets shown in these FAQs, wherever `np` is present is defined as  `import numpy as np`.
+
+
+Section 1 - Using |galario|
+--------------------------------------------
+
+.. _FAQ1.1:
+
+**Question 1.1. Why do I get an error about non C-contiguous arrays?**
+
+I run this line (or a similar one with `chiImage()`, `sampleProfile()` or `sampleImage()`):
+
+.. code-block:: python
+
+    chi2 = chi2Profile(f, Rmin, dR, nxy, dxy, u, v, Re, Im, w)
+
+
+and I get the following error:
+
+.. code-block:: bash
+
+  File "libcommon.pyx", line 630, in libcommon.chi2Profile
+  File "stringsource", line 653, in View.MemoryView.memoryview_cwrapper
+  File "stringsource", line 348, in View.MemoryView.memoryview.__cinit__
+  ValueError: ndarray is not C-contiguous
+
+The issue is caused by the arrays `u`, `v`, `Re`, `Im`, `w` being not C-contiguous, which is a requirement for the C++ code in GALARIO. You can check whether a NumPy array `x` is C-contiguous by printing `x.flags`.
+
+The `u`, `v`, `Re`, `Im`, `w` arrays are usually not C-contiguous if you read them, e.g., from an ASCII uvtable with a `np.loadtxt()` command and the `unpack=True` option (or something equivalent).
+
+**SOLUTION:** Make the arrays C-contiguous with `np.ascontiguousarray()` command:
+
+.. code-block:: python
+
+    u = np.ascontiguousarray(u)
+    v = np.ascontiguousarray(v)
+    Re = np.ascontiguousarray(Re)
+    Im = np.ascontiguousarray(Im)
+    w = np.ascontiguousarray(w)
+
+Alternatively, you can make the arrays contiguous all at once:
+
+.. code-block:: python
+
+    u, v, Re, Im, w = np.require([u, v, Re, Im, w], requirements='C')
+
+
+
+..
+    I get this error:
+    ImportError                               Traceback (most recent call last)
+    <ipython-input-144-ee2f01adc0c4> in <module>()
+    ----> 1 from galario.double_cuda import sampleImage
+    /Users/tdavis/anaconda/lib/python3.5/site-packages/galario/double_cuda/__init__.py in <module>()
+    ----> 1 from .libcommon import *
+          2
+          3 _init()
+          4
+          5 import atexit
+    ImportError: No module named 'galario.double_cuda.libcommon'
+
+..
+    2) I am mainly interested in using this for line cubes.
+    Is the best way to do that to loop over and do each channel separately?
+    Does that add overhead? Any way to cut that down?
+
+..
+    I have a single source, far from the center, what's the best way of modelling it?
+    sampleProfile with dRa, dDec or sampleImage?
+    Anything to pay attention to? -> nxy, dxy
+
+    How do I check if nxy, dxy chosen are correct?
+
+    How can I use more than one GPU?

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -3,6 +3,9 @@
    You can adapt this file completely to your liking, but it should at least
    contain the root `toctree` directive.
 
+.. _email: mtazzari@ast.cam.ac.uk
+
+
 .. image:: images/galario.jpg
    :scale: 40 %
    :alt: Galario logo. Credit: Tazzari, Beaujean, Testi.
@@ -69,6 +72,8 @@ Useful recipes for the CPU/GPU management and the model image creation: see the 
 
 Detailed documentation of each Python and C++ function: see the :doc:`Python-API <py-api>` and :doc:`C++ API <C++-api>` pages.
 
+Stuck on an issue? Check the :doc:`Frequently Asked Questions <FAQ>` page, or send me an `email`_.
+
 License and Attribution
 -----------------------
 If you use |galario| for your research please cite Tazzari, Beaujean and Testi (2018) MNRAS **476** 4527 `[MNRAS] <https://doi.org/10.1093/mnras/sty409>`_ `[arXiv] <https://arxiv.org/abs/1709.06999>`_ `[ADS] <http://adsabs.harvard.edu/abs/2018MNRAS.476.4527T>`_.
@@ -123,4 +128,5 @@ Contents
     C++ API <C++-api>
     C++ Example <C++-example>
     Publications <publications>
+    FAQ <FAQ>
     License <license>

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -53,12 +53,12 @@ Fit a single-wavelength data set
 
     .. code-block:: python
 
-        u, v, Re, Im, w = np.loadtxt("uvtable.txt", unpack=True)
+        u, v, Re, Im, w = np.require(np.loadtxt("uvtable.txt", unpack=True), requirements='C')
         wle = 1e-3  # [m]
         u /= wle
         v /= wle
 
-    where the :math:`u_j` and :math:`v_j` coordinates have been converted in units of the observing wavelength, 1 mm in this example.
+    where the :math:`u_j` and :math:`v_j` coordinates have been converted in units of the observing wavelength, 1 mm in this example. The `np.require` command is necessary to ensure that the arrays are C-contiguous as required by |galario| (see :ref:`FAQ 1.1 <FAQ1.1>`).
 
 **2) Determine the image size**
     Once imported the uv table, we can start using |galario| to compute the optimal image size

--- a/python/test_galario.py
+++ b/python/test_galario.py
@@ -210,8 +210,8 @@ def test_interpolate(size, real_type, complex_type, rtol, atol, acc_lib):
     ImInt = AmpInt * np.sin(PhaseInt)
 
     complexInt = acc_lib.interpolate(ft, du,
-                                     udat.astype(real_type),
-                                     vdat.astype(real_type))
+                                     np.ascontiguousarray(udat.astype(real_type)),
+                                     np.ascontiguousarray(vdat.astype(real_type)))
 
     assert_allclose(ReInt, complexInt.real, rtol, atol)
     assert_allclose(ImInt, complexInt.imag, rtol, atol)
@@ -594,8 +594,8 @@ def test_loss(nsamples, real_type, complex_type, rtol, atol, acc_lib, pars):
 
     complexInt = acc_lib.interpolate(py_shift_cmplx.astype(complex_type),
                                      du,
-                                     udat.astype(real_type),
-                                     vdat.astype(real_type))
+                                     np.ascontiguousarray(udat.astype(real_type)),
+                                     np.ascontiguousarray(vdat.astype(real_type)))
 
     assert_allclose(ReInt, complexInt.real, rtol, atol)
     assert_allclose(ImInt, complexInt.imag, rtol, atol)

--- a/python/test_galario.py
+++ b/python/test_galario.py
@@ -197,7 +197,7 @@ def test_interpolate(size, real_type, complex_type, rtol, atol, acc_lib):
     uroti = uroti.astype(real_type)
     vroti = vroti.astype(real_type)
 
-    ft = np.fft.fftshift(np.fft.fft2(np.fft.fftshift(reference_image))).astype(complex_type)
+    ft = np.fft.fftshift(np.fft.fft2(np.fft.fftshift(reference_image))).astype(complex_type, order='C')
 
     ReInt = int_bilin_MT(ft.real, uroti, vroti)
     ImInt = int_bilin_MT(ft.imag, uroti, vroti)
@@ -210,8 +210,8 @@ def test_interpolate(size, real_type, complex_type, rtol, atol, acc_lib):
     ImInt = AmpInt * np.sin(PhaseInt)
 
     complexInt = acc_lib.interpolate(ft, du,
-                                     np.ascontiguousarray(udat.astype(real_type)),
-                                     np.ascontiguousarray(vdat.astype(real_type)))
+                                     udat.astype(real_type),
+                                     vdat.astype(real_type))
 
     assert_allclose(ReInt, complexInt.real, rtol, atol)
     assert_allclose(ImInt, complexInt.imag, rtol, atol)
@@ -592,10 +592,10 @@ def test_loss(nsamples, real_type, complex_type, rtol, atol, acc_lib, pars):
     ReInt = AmpInt * np.cos(PhaseInt)
     ImInt = AmpInt * np.sin(PhaseInt)
 
-    complexInt = acc_lib.interpolate(py_shift_cmplx.astype(complex_type),
+    complexInt = acc_lib.interpolate(py_shift_cmplx.astype(complex_type, order='C'),
                                      du,
-                                     np.ascontiguousarray(udat.astype(real_type)),
-                                     np.ascontiguousarray(vdat.astype(real_type)))
+                                     udat.astype(real_type),
+                                     vdat.astype(real_type))
 
     assert_allclose(ReInt, complexInt.real, rtol, atol)
     assert_allclose(ImInt, complexInt.imag, rtol, atol)


### PR DESCRIPTION
This PR started off to amend docs about ensuring arrays are C-contiguous in the quickstart example, as I received a question about "arrays not being C-contiguous" error).
Then decided to create the FAQ page on which all these support questions will be collected, to fix #147.
During Travis-testing I spotted that the `test_interpolate` and `test_loss` failed (see builds [208-211](https://travis-ci.org/mtazzari/galario/builds/411643749) on Travis).