### PR TITLE
Prepare for conda-forge upgrades

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,13 +27,6 @@ if(NOT CMAKE_BUILD_TYPE)
       FORCE)
 endif(NOT CMAKE_BUILD_TYPE)
 
-# if inside a conda env, install everything in there
-# if (DEFINED ENV{CONDA_PREFIX} AND CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT)
-if (DEFINED ENV{CONDA_PREFIX})
-  message(STATUS "Installing inside conda env at $ENV{CONDA_PREFIX}")
-  set(CMAKE_INSTALL_PREFIX "$ENV{CONDA_PREFIX}")
-endif()
-
 # ship extra findXXX.cmake in `cmake/`
 # APPEND doesn't propagate variable to subdirectory
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,8 +47,8 @@ if(NOT DEFINED GALARIO_CHECK_CUDA)
   endif()
 endif()
 if(GALARIO_CHECK_CUDA)
-  # find_package(CUDA)
-  enable_language(CUDA)
+  find_package(CUDA)
+  #enable_language(CUDA)
 endif()
 
 # has to come before subdirectories are added

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -27,6 +27,13 @@ if(NOT CMAKE_BUILD_TYPE)
       FORCE)
 endif(NOT CMAKE_BUILD_TYPE)
 
+# if inside a conda env, install everything in there
+if (CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT AND DEFINED ENV{CONDA_PREFIX})
+  # https://stackoverflow.com/questions/21437514/
+  set(CMAKE_INSTALL_PREFIX "$ENV{CONDA_PREFIX}" CACHE PATH "Set the prefix based on conda environment" FORCE)
+  message(STATUS "Installing inside conda env at ${CMAKE_INSTALL_PREFIX}")
+endif()
+
 # ship extra findXXX.cmake in `cmake/`
 # APPEND doesn't propagate variable to subdirectory
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/cmake")

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,7 +47,8 @@ if(NOT DEFINED GALARIO_CHECK_CUDA)
   endif()
 endif()
 if(GALARIO_CHECK_CUDA)
-  find_package(CUDA)
+  # find_package(CUDA)
+  enable_language(CUDA)
 endif()
 
 # has to come before subdirectories are added

--- a/docs/FAQ.rst
+++ b/docs/FAQ.rst
@@ -38,7 +38,7 @@ and I get the following error:
   File "stringsource", line 348, in View.MemoryView.memoryview.__cinit__
   ValueError: ndarray is not C-contiguous
 
-The issue is caused by one of the arrays passed in input to `chi2Profile` being not C-contiguous, which is a requirement for the C++ code in GALARIO. You can check whether a NumPy array `x` is C-contiguous by printing `x.flags`. The first action to debug this issue is to print the flags fo all the arrays in input to the function.
+The issue is caused by one of the arrays passed in input to `chi2Profile` being not C-contiguous, which is a requirement for the C++ code in GALARIO. You can check whether a NumPy array `x` is C-contiguous by printing `x.flags`. The first action to debug this issue is to print the flags of all the arrays in input to the function.
 
 Typically this happens with the `u`, `v`, `Re`, `Im`, `w` arrays that are not C-contiguous if you read them, e.g., from an ASCII uvtable with a `np.loadtxt()` command and the `unpack=True` option (or something equivalent).
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -66,17 +66,17 @@ To manually turn ON/OFF the GPU CUDA compilation, see :ref:`these instructions <
         conda create --name galario3 python=3 numpy cython pytest
         source activate galario3
 
- 2. Use `cmake` to prepare the compilation and `make all` to compile. From within `galario/build/`:
+ 3. Use `cmake` to prepare the compilation from within `galario/build/`:
 
     .. code-block:: bash
 
-       cmake ..
+       cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX ..
 
     This command will produce configuration and compilation logs listing all the libraries and the compilers that are being used.
     It will use the internet connection to automatically download `this <https://github.com/UCL/GreatCMakeCookOff>`_ additional library (1.5 MB).
+    The option `-DCMAKE_INSTALL_PREFIX` sets the directory where |galario| will be installed equal to the content of `$CONDA_PREFIX`. If you are inside a `conda` environment, then `$CONDA_PREFIX` is already populated with the correct directory. For |galario|v > 1.2 it is mandatory to provide this option.
 
-
- 3. Use `make` to build |galario| and `make install` to install it inside the active environment:
+ 4. Use `make` to build |galario| and `make install` to install it inside the active environment:
 
     .. code-block:: bash
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -30,7 +30,8 @@ To compile |galario| you will need:
 
 * a working internet connection (to download 1.5 MB of an external library)
 * either `g++`>=4.8.1 or `clang++`>=3.3 with full support of C++11. To use multiple threads, the compiler has to support `openMP <http://www.openmp.org/resources/openmp-compilers/>`_
-* `cmake <https://cmake.org>`_ and `make`
+* `cmake`: download from the `cmake website <https://cmake.org>`_ or install with `conda install -c conda-forge cmake` 
+* `make`
 * the `FFTW libraries <http://www.fftw.org>`_, for the CPU version: more details are given :ref:`below <fftw_requirement>`
 * [optional] the `CUDA toolkit <https://developer.nvidia.com/cuda-toolkit>`_ >=8.0 for the GPU version: it can be easily installed from the `NVIDIA website <https://developer.nvidia.com/cuda-toolkit>`_
 * [optional] Python and numpy for Python bindings to the CPU and GPU

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -70,7 +70,7 @@ To manually turn ON/OFF the GPU CUDA compilation, see :ref:`these instructions <
 
     .. code-block:: bash
 
-       cmake -DCMAKE_INSTALL_PREFIX=$CONDA_PREFIX ..
+       cmake ..
 
     This command will produce configuration and compilation logs listing all the libraries and the compilers that are being used.
     It will use the internet connection to automatically download `this <https://github.com/UCL/GreatCMakeCookOff>`_ additional library (1.5 MB).

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -59,11 +59,11 @@ To manually turn ON/OFF the GPU CUDA compilation, see :ref:`these instructions <
  2. to make the compilation easier, let's work in a Python environment. |galario| works with both Python 2 and 3.
 
     For example, if you are using the `Anaconda <https://www.continuum.io/downloads>`_ distribution, you can create and
-    activate a Python 3 environment with:
+    activate a Python 3.6 environment with:
 
     .. code-block:: bash
 
-        conda create --name galario3 python=3 numpy cython pytest
+        conda create --name galario3 python=3.6 numpy cython pytest scipy
         source activate galario3
 
  3. Use `cmake` to prepare the compilation from within `galario/build/`:
@@ -82,7 +82,7 @@ To manually turn ON/OFF the GPU CUDA compilation, see :ref:`these instructions <
 
         make && make install
 
-    If the installation fails due to permission problems, you either have to use `sudo make install`, or see the :ref:`instructions below <install_details>` to specify an alternate installation path.
+    If the installation fails due to permission problems, you either have to use `sudo make install`, or see the :ref:`instructions below <install_details>` to specify an alternate installation path. Permission problems may arise when you are using, e.g., a *shared* conda environment: in that case, it is preferable to create your own environment in a directory where you have write permissions.
 
 These instructions should be sufficient in most cases, but if you have problems
 or want more fine-grained control, check out the details below. If you find

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -74,7 +74,6 @@ To manually turn ON/OFF the GPU CUDA compilation, see :ref:`these instructions <
 
     This command will produce configuration and compilation logs listing all the libraries and the compilers that are being used.
     It will use the internet connection to automatically download `this <https://github.com/UCL/GreatCMakeCookOff>`_ additional library (1.5 MB).
-    The option `-DCMAKE_INSTALL_PREFIX` sets the directory where |galario| will be installed equal to the content of `$CONDA_PREFIX`. If you are inside a `conda` environment, then `$CONDA_PREFIX` is already populated with the correct directory. For |galario|v > 1.2 it is mandatory to provide this option.
 
  4. Use `make` to build |galario| and `make install` to install it inside the active environment:
 

--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -175,15 +175,15 @@ Fit a single-wavelength data set
     .. code-block:: python
 
         def lnpriorfn(p, par_ranges):
-        """ Uniform prior probability function """
+            """ Uniform prior probability function """
 
-        for i in range(len(p)):
-            if p[i] < par_ranges[i][0] or p[i] > par_ranges[i][1]:
-                return -np.inf
+            for i in range(len(p)):
+                if p[i] < par_ranges[i][0] or p[i] > par_ranges[i][1]:
+                    return -np.inf
 
-        jacob = -p[0]       # jacobian of the log transformation
+            jacob = -p[0]       # jacobian of the log transformation
 
-        return jacob
+            return jacob
 
     which, up to a constant, basically checks that `p` lies inside the rectangular domain defined by the extents in `p_ranges`.
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -48,20 +48,11 @@ endif()
 ###
 # installation
 ###
-# to set ${PYTHON_PKG_DIR}. It is prepended by ${CMAKE_INSTALL_PREFIX} if set by user
+# to set ${PYTHON_PKG_DIR}. It is prepended by ${CMAKE_INSTALL_PREFIX} if set
 include(PythonInstall)
 
-# if conda environment is found, prefer that. I know, the name
-# DEFAULT_PYTHON_PKG_DIR is confusing but I didn't choose it
-if(DEFINED ENV{CONDA_PREFIX})
-  set(GALARIO_PYTHON_PKG_DIR "${DEFAULT_PYTHON_PKG_DIR}" CACHE PATH
-    "Current python install path"
-    )
-else()
-  set(GALARIO_PYTHON_PKG_DIR "${PYTHON_PKG_DIR}" CACHE PATH
-  "Current python install path"
-  )
-endif()
+# I guess variable has to be in cache to survive reinvocations of cmake that happen during building
+set(GALARIO_PYTHON_PKG_DIR "${PYTHON_PKG_DIR}" CACHE PATH "Current python install path")
 
 # on unix: install .py and .so relative to ${CMAKE_INSTALL_PREFIX_INITIALIZED_TO_DEFAULT}
 install(DIRECTORY ${PYGALARIO_DIR}

--- a/python/wrap_lib.cmake
+++ b/python/wrap_lib.cmake
@@ -37,7 +37,6 @@ function(wrap_lib)
   else()
     set(GALARIO_DOUBLE_PRECISION 0)
     set(outdir "${PYGALARIO_DIR}/single")
-    # append `f` for single precision as for FFTW3
     set(suffix "_single")
   endif()
   if(WRAP_LIB_CUDA)


### PR DESCRIPTION
Some conda-forge ugprades require passing mandatory field `CMAKE_INSTALL_PREFIX` when doing `cmake ..`.
See https://github.com/conda-forge/galario-feedstock/pull/1 and my attempts to make the tests pass. The last test didn't pass because `make install` tries to install inside the `CONDA_PREFIX`, but actually the conda-forge automated build system wants to install it into another temporary environment.
As suggested, I needed to remove the default installation in the `CONDA_PREFIX` from the `Cmakelists.txt`.

In preparation to that PR and the recent PR3 on the adoption of Python 3.7 (https://github.com/conda-forge/galario-feedstock/pull/3).

All tests pass on CPU, galario is correctly installed in the directory provided in `CMAKE_INSTALL_PREFIX` or, if the option is not provided, `make install` complains. 

I need to test on GPU.