### PR TITLE
(wip) Release utils

### DIFF
--- a/docs/py-api.rst
+++ b/docs/py-api.rst
@@ -67,6 +67,17 @@ Other useful functions
 .. autofunction:: galario.double.reduce_chi2
 
 
+
+Utilities
+---------
+The `galario.utils` module contains a number of general purpose functions as well as Python version of the compiled functions present in `galario.single` and `galario.double`.
+
+.. autofunction:: galario.utils.sweep_ref
+.. autofunction:: galario.utils.apply_rotation
+.. autofunction:: galario.utils.apply_phase_array
+.. autofunction:: galario.utils.unique_part
+.. autofunction:: galario.utils.assert_allclose
+
 .. _galario_exceptions:
 
 Exceptions

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -35,6 +35,10 @@ configure_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/__init__.py.in"
   "${PYGALARIO_DIR}/__init__.py"
   )
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/utils.py"
+  "${PYGALARIO_DIR}/utils.py"
+  )
 
 include(wrap_lib.cmake)
 wrap_lib()

--- a/python/__init__.py.in
+++ b/python/__init__.py.in
@@ -27,5 +27,6 @@ if HAVE_CUDA:
 
 from . import single
 from . import double
+from . import utils
 
 from .double import arcsec, au, cgs_to_Jy, pc, deg

--- a/python/speed_benchmark.py
+++ b/python/speed_benchmark.py
@@ -87,16 +87,16 @@ def setup_chi2Image(nxy, nsamples):
     PA = 80.
 
     maxuv_generator = 3e3
-    udat, vdat = create_sampling_points(nsamples, maxuv_generator, dtype='float64')
+    u, v = create_sampling_points(nsamples, maxuv_generator, dtype='float64')
     x, _, w = generate_random_vis(nsamples, options.dtype)
 
-    _, _, maxuv = matrix_size(udat, vdat)
+    _, _, maxuv = matrix_size(u, v)
     dxy = 1 / maxuv
 
     # create model image (it happens to have 0 imaginary part)
     image_ref = create_reference_image(size=nxy, kernel='gaussian', dtype=options.dtype)
 
-    return image_ref, dxy, udat, vdat, x.real.copy(), x.imag.copy(), w, dRA, dDec, PA
+    return image_ref, dxy, u, v, x.real.copy(), x.imag.copy(), w, dRA, dDec, PA
 
 
 def setup_chi2Profile(nxy, nsamples):
@@ -113,19 +113,19 @@ def setup_chi2Profile(nxy, nsamples):
 
     # generate the samples
     maxuv_generator = 3e3
-    udat, vdat = create_sampling_points(nsamples, maxuv_generator, dtype=options.dtype)
+    u, v = create_sampling_points(nsamples, maxuv_generator, dtype=options.dtype)
     x, _, w = generate_random_vis(nsamples, options.dtype)
 
-    _, _, maxuv = matrix_size(udat, vdat)
+    _, _, maxuv = matrix_size(u, v)
     maxuv /= wle_m
     dxy = 1 / maxuv
     # compute the matrix size and maxuv
-    # nxy, dxy = g_double.get_image_size(udat/wle_m, vdat/wle_m)
+    # nxy, dxy = g_double.get_image_size(u/wle_m, v/wle_m)
 
     # compute radial profile
     intensity = radial_profile(Rmin, dR, nrad, profile_mode, dtype=options.dtype, gauss_width=150.*arcsec)
 
-    return intensity, Rmin, dR, nxy, dxy, udat/wle_m, vdat/wle_m, x.real.copy(), x.imag.copy(), w, dRA, dDec, inc, PA
+    return intensity, Rmin, dR, nxy, dxy, u/wle_m, v/wle_m, x.real.copy(), x.imag.copy(), w, dRA, dDec, inc, PA
 
 
 def do_timing(options, input_data, gpu=False, tpb=0, omp_num_threads=0):


### PR DESCRIPTION
In `galario.utils` there are some general purpose functions that are useful. At the moment there is no way of calling them.
Here, I add them to the installed payload and I make them importable as 
```py
from galario import utils
```
or
```py
from galario.utils import sweep_ref
```
This could be a framework to release future other Python-only functions.
It would allow, e.g., to distribute a Python version as a prototype of future CPU/GPU accelerated version.
