### PR TITLE
Improve docs: add uvplot code example and publication link

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,11 @@
+1.2.1 (2018-11-01)
+++++++++++++++++++
+
+- [core] Add support for Python 3.7
+- [docs] New FAQ page with Frequently Asked Questions.
+- [docs] Better documentation of `get_coords_meshgrid` function.
+- [cmake] By default, install |galario| in the active conda environment directory unless `cmake -DCMAKE_INSTALL_PREFIX=/path/...` is specified.
+
 1.2 (2018-06-20)
 ++++++++++++++++
 
@@ -16,14 +24,14 @@
 
 1.0.2 (2017-12-19)
 ++++++++++++++++++
-- [interface] CPU version can now be installed with `conda install -c conda-forge galario`.
+- [interface] CPU version can now be installed with `conda install -c conda-forge |galario|`.
 - [core/bugfix] Fix memory leak in GPU version.
 - [core] Allow multiple processes to use the GPU concurrently by default.
 - [docs] Improve installation notes and quickstart example.
 
 1.0.1 (2017-10-05)
 ++++++++++++++++++
-- [interface] Allow uninstalling galario with `make uninstall`.
+- [interface] Allow uninstalling |galario| with `make uninstall`.
 - [interface] Allow enabling/disabling check for CUDA on Mac OS with `cmake -DGALARIO_CHECK_CUDA=1`.
 
 1.0 (2017-09-19)

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@ given a model image (or an axisymmetric brightness profile) and their comparison
 
 Check out the [documentation](https://mtazzari.github.io/galario/) and the [installation instructions](https://mtazzari.github.io/galario/install.html).
 
+**galario** is used in a growing number of publications. You can find the updated list of publications [[at this link]](https://ui.adsabs.harvard.edu/#search/q=citations(bibcode%3A2018MNRAS.476.4527T)%20&sort=date%20desc%2C%20bibcode%20desc&p_=0). 
+
 If you use **galario** for your research please cite  Tazzari, Beaujean and Testi (2018) MNRAS **476** 4527 [[MNRAS]](https://doi.org/10.1093/mnras/sty409) [[arXiv]](https://arxiv.org/abs/1709.06999) [[ADS]](http://adsabs.harvard.edu/abs/2018MNRAS.476.4527T):
 ```
 @ARTICLE{2018MNRAS.476.4527T,

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -7,18 +7,22 @@ Operating system
 -------------------
 |galario| runs on Linux and Mac OS X. Windows is not supported.
 
-Installing via conda
---------------------
+Quickest installation: using conda
+----------------------------------
 
 By far the easiest way to install |galario| is via `conda <https://conda.io>`_.
 If you are new to `conda`, you may want to start with the minimal `miniconda
 <https://repo.continuum.io/miniconda/>`_. With `conda` all dependencies are
 installed automatically and you get access to |galario|'s C++ core and python
 bindings, both with support for multithreading.
+To install |galario|:
 
 .. code-block:: bash
 
    conda install -c conda-forge galario
+
+
+To create a conda environment for |galario|, see Section 1.4, step 2.
 
 Due to technical limitations, the conda package does not support GPUs at the
 moment. If you want to use a GPU, read on as you have to build |galario| by hand.

--- a/docs/publications.rst
+++ b/docs/publications.rst
@@ -2,16 +2,6 @@
 Publications that used |galario|
 ================================
 
-In this page we aim to keep a record of the studies that used |galario|.
-Here is a (tentatively updated) list (most recent first):
+We use the NASA Astrophysics Data system (ADS) to keep track of the publications that used |galario|.
 
- - `Pinilla, Tazzari, Pascucci, et al. (2018) ApJ in press <https://ui.adsabs.harvard.edu/#abs/2018arXiv180407301P>`_
- - `Fedele, Tazzari, Booth, et al. (2018) A&A 610 A24 <https://ui.adsabs.harvard.edu/#abs/2018A&A...610A..24F>`_
- - `Tazzari, Testi, Natta, et al. (2017) A&A 6060 A88 <https://ui.adsabs.harvard.edu/#abs/2017A&A...606A..88T>`_
- - `Testi, Natta, Scholz, et al. (2016) A&A 593 A111 <https://ui.adsabs.harvard.edu/#abs/2016A%26A...593A.111T>`_
- - `Guidi, Tazzari, Testi, et al. (2016) 588 A112 <https://ui.adsabs.harvard.edu/#abs/2016A&A...588A.112G>`_
- - `Tazzari, Testi, Ercolano, et al. (2016) A&A 588 A53 <https://ui.adsabs.harvard.edu/#abs/2016A&A...588A..53T>`_
-
-If your paper should be added to this list, just `let us know <mtazzari@ast.cam.ac.uk>`_!
-
-Alternatively, fork the repository, edit this file by yourself and open a pull request.
+You can find the updated list of publications `at this link <https://ui.adsabs.harvard.edu/#search/q=citations(bibcode%3A2018MNRAS.476.4527T)%20&sort=date%20desc%2C%20bibcode%20desc&p_=0>`_.


### PR DESCRIPTION
The docs did not report the actual code used to generate the uvplot.
Also, there was no way to reproduce the fit results as the uvtable was not provided.
Now I added the code to generate the uvplot and I posted online the ASCII version of the uvtable for people to download and get started with galario.
I also replaced the publications page with a dynamic link to galario's paper citations.